### PR TITLE
Fix & Update `<ranges>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,37 +358,38 @@ Description
 
 * `<concepts>`
 
-  |                         | Introduced | Revision |
-  |-------------------------|------------|----------|
-  | `same_as`               | ![][c20ok] |          |
-  | `derived_from`          | ![][c20ok] |          |
-  | `convertible_to`        | ![][c20ok] |          |
-  | `common_reference_with` | ![][c20ok] |          |
-  | `common_with`           | ![][c20ok] |          |
-  | `integral`              | ![][c20ok] |          |
-  | `signed_integral`       | ![][c20ok] |          |
-  | `unsigned_integral`     | ![][c20ok] |          |
-  | `floating_point`        | ![][c20ok] |          |
-  | `assignable_from`       | ![][c20ok] |          |
-  | `swappable`             | ![][c20ok] |          |
-  | `destructible`          | ![][c20ok] |          |
-  | `constructible_from`    | ![][c20ok] |          |
-  | `default_initializable` | ![][c20ok] |          |
-  | `move_constructible`    | ![][c20ok] |          |
-  | `copy_constructible`    | ![][c20ok] |          |
-  | `equality_comparable`   | ![][c20ok] |          |
-  | `totally_ordered`       | ![][c20ok] |          |
-  | `movable`               | ![][c20ok] |          |
-  | `copyable`              | ![][c20ok] |          |
-  | `semiregular`           | ![][c20ok] |          |
-  | `regular`               | ![][c20ok] |          |
-  | `invocable`             | ![][c20ok] |          |
-  | `regular_invocable`     | ![][c20ok] |          |
-  | `predicate`             | ![][c20ok] |          |
-  | `relation`              | ![][c20ok] |          |
-  | `equivalence_relation`  | ![][c20ok] |          |
-  | `strict_weak_order`     | ![][c20ok] |          |
-  | `ranges::swap`          | ![][c20ok] |          |
+  |                            | Introduced | Revision   |
+  |----------------------------|------------|------------|
+  | `same_as`                  | ![][c20ok] |            |
+  | `derived_from`             | ![][c20ok] |            |
+  | `convertible_to`           | ![][c20ok] |            |
+  | `common_reference_with`    | ![][c20ok] |            |
+  | `common_with`              | ![][c20ok] |            |
+  | `integral`                 | ![][c20ok] |            |
+  | `signed_integral`          | ![][c20ok] |            |
+  | `unsigned_integral`        | ![][c20ok] |            |
+  | `floating_point`           | ![][c20ok] |            |
+  | `assignable_from`          | ![][c20ok] |            |
+  | `swappable`                | ![][c20ok] |            |
+  | `destructible`             | ![][c20ok] |            |
+  | `constructible_from`       | ![][c20ok] |            |
+  | `default_initializable`    | ![][c20ok] |            |
+  | `move_constructible`       | ![][c20ok] |            |
+  | `copy_constructible`       | ![][c20ok] |            |
+  | `equality_comparable`      | ![][c20ok] |            |
+  | `equality_comparable_with` | ![][c20ok] | ![][c23ok] |
+  | `totally_ordered`          | ![][c20ok] |            |
+  | `movable`                  | ![][c20ok] |            |
+  | `copyable`                 | ![][c20ok] |            |
+  | `semiregular`              | ![][c20ok] |            |
+  | `regular`                  | ![][c20ok] |            |
+  | `invocable`                | ![][c20ok] |            |
+  | `regular_invocable`        | ![][c20ok] |            |
+  | `predicate`                | ![][c20ok] |            |
+  | `relation`                 | ![][c20ok] |            |
+  | `equivalence_relation`     | ![][c20ok] |            |
+  | `strict_weak_order`        | ![][c20ok] |            |
+  | `ranges::swap`             | ![][c20ok] |            |
 
 * `<coroutine>` N/A
 

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Description
   | `ranges::contiguous_range`                                        | ![][c20ok]           |            |
   | `ranges::common_range`                                            | ![][c20ok]           |            |
   | `ranges::viewable_range`                                          | ![][c20ok]           |            |
-  | `ranges::constant_range`                                          | ![][c20ok]           |            |
+  | `ranges::constant_range`                                          | ![][c23ok]           |            |
   | `ranges::to`                                                      | ![][c23ok] (Partial) |            |
   | `ranges::iterator_t`                                              | ![][c20ok]           |            |
   | `ranges::const_iterator_t`                                        | ![][c23ok]           |            |
@@ -670,11 +670,11 @@ Description
   | `ranges::range_size_t`                                            | ![][c20ok]           |            |
   | `ranges::range_value_t`                                           | ![][c20ok]           |            |
   | `ranges::range_refernce_t`                                        | ![][c20ok]           |            |
-  | `ranges::range_const_reference_t`                                 | ![][c20ok]           |            |
+  | `ranges::range_const_reference_t`                                 | ![][c23ok]           |            |
   | `ranges::range_rvalue_reference_t`                                | ![][c20ok]           |            |
   | `ranges::range_common_reference_t`                                | ![][c20ok]           |            |
   | `ranges::view_interface`                                          | ![][c20ok]           | ![][c23ok] |
-  | `ranges::subrange`                                                | ![][c20ok]           |            |
+  | `ranges::subrange`                                                | ![][c20ok]           | ![][c23ok] |
   | `ranges::dangling`                                                | ![][c20ok]           |            |
   | `ranges::borrowed_iterator_t`                                     | ![][c20ok]           |            |
   | `ranges::borrowed_subrange_t`                                     | ![][c20ok]           |            |

--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ Description
   | `ranges::range_const_reference_t`                                 | ![][c20ok]           |            |
   | `ranges::range_rvalue_reference_t`                                | ![][c20ok]           |            |
   | `ranges::range_common_reference_t`                                | ![][c20ok]           |            |
-  | `ranges::view_interface`                                          | ![][c20ok]           |            |
+  | `ranges::view_interface`                                          | ![][c20ok]           | ![][c23ok] |
   | `ranges::subrange`                                                | ![][c20ok]           |            |
   | `ranges::dangling`                                                | ![][c20ok]           |            |
   | `ranges::borrowed_iterator_t`                                     | ![][c20ok]           |            |

--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ Description
   | `ranges::ref_view`                                                | ![][c20ok]           |            |
   | `ranges::owning_view`                                             | ![][c20ok]           |            |
   | `ranges::filter_view`<br/>`views::filter`                         | ![][c20ok]           |            |
-  | `ranges::transform_view`<br/>`views::transform`                   | ![][c20ok]           |            |
+  | `ranges::transform_view`<br/>`views::transform`                   | ![][c20ok]           | ![][c23ok] |
   | `ranges::take_view`<br/>`views::take`                             | ![][c20ok]           |            |
   | `ranges::take_while_view`<br/>`views::take_while`                 | ![][c20ok]           |            |
   | `ranges::drop_view`<br/>`views::drop`                             | ![][c20ok]           |            |

--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ Description
   | `ranges::transform_view`<br/>`views::transform`                   | ![][c20ok]           | ![][c23ok] |
   | `ranges::take_view`<br/>`views::take`                             | ![][c20ok]           |            |
   | `ranges::take_while_view`<br/>`views::take_while`                 | ![][c20ok]           |            |
-  | `ranges::drop_view`<br/>`views::drop`                             | ![][c20ok]           |            |
+  | `ranges::drop_view`<br/>`views::drop`                             | ![][c20ok]           | ![][c23ok] |
   | `ranges::drop_while_view`<br/>`views::drop_while`                 | ![][c20ok]           |            |
   | `ranges::join_view`<br/>`views::join`                             | ![][c20ok]           |            |
   | `ranges::lazy_split_view`<br/>`views::lazy_split`                 | ![][c20ok]           |            |

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ Description
   | `ranges::drop_view`<br/>`views::drop`                             | ![][c20ok]           | ![][c23ok] |
   | `ranges::drop_while_view`<br/>`views::drop_while`                 | ![][c20ok]           |            |
   | `ranges::join_view`<br/>`views::join`                             | ![][c20ok]           |            |
-  | `ranges::lazy_split_view`<br/>`views::lazy_split`                 | ![][c20ok]           |            |
+  | `ranges::lazy_split_view`<br/>`views::lazy_split`                 | ![][c20no]           |            |
   | `ranges::split_view`<br/>`views::split`                           | ![][c20ok]           |            |
   | `views::counted`                                                  | ![][c20ok]           |            |
   | `ranges::common_view`<br/>`views::common`                         | ![][c20ok]           |            |

--- a/include/preview/__functional/bind_back.h
+++ b/include/preview/__functional/bind_back.h
@@ -51,7 +51,7 @@ template<typename F, typename... Args, std::enable_if_t<conjunction<
     std::is_move_constructible<std::decay_t<Args>>...
 >::value, int> = 0>
 constexpr auto bind_back(F&& f, Args&&... args) {
-  return detail::bind_back_object<std::decay_t<F>, std::decay_t<Args>...>{
+  return detail::bind_back_object<std::decay_t<F>, Args&&...>{
       detail::bind_object_ctor_tag{},
       std::forward<F>(f),
       std::forward<Args>(args)...

--- a/include/preview/__functional/bind_front.h
+++ b/include/preview/__functional/bind_front.h
@@ -49,7 +49,7 @@ template<typename F, typename... Args, std::enable_if_t<conjunction<
     std::is_move_constructible<std::decay_t<Args>>...
 >::value, int> = 0>
 constexpr auto bind_front(F&& f, Args&&... args) {
-  return detail::bind_front_object<std::decay_t<F>, std::decay_t<Args>...>{
+  return detail::bind_front_object<std::decay_t<F>, Args&&...>{
     detail::bind_object_ctor_tag{},
     std::forward<F>(f),
     std::forward<Args>(args)...

--- a/include/preview/__functional/detail/bind_base.h
+++ b/include/preview/__functional/detail/bind_base.h
@@ -32,7 +32,6 @@ class bind_object_base {
   constexpr typename bind_invoke_result<Derived&, U&&...>::type
   operator()(U&&... args) & noexcept(bind_nothrow_invocable<Derived&, U&&...>::value) {
     return call(*this, std::forward<U>(args)...);
-    return Derived::call(derived(), index_sequence{}, std::forward<U>(args)...);
   }
 
   template<typename... U>

--- a/include/preview/__iterator/contiguous_iterator.h
+++ b/include/preview/__iterator/contiguous_iterator.h
@@ -10,6 +10,7 @@
 #include "preview/__concepts/derived_from.h"
 #include "preview/__concepts/same_as.h"
 #include "preview/__concepts/requires_expression.h"
+#include "preview/__iterator/detail/have_cxx20_iterator.h"
 #include "preview/__iterator/detail/iter_concept.h"
 #include "preview/__iterator/iterator_traits/legacy_random_access_iterator.h"
 #include "preview/__iterator/iter_reference_t.h"
@@ -48,11 +49,11 @@ struct contiguous_iterator_impl : std::false_type {};
 template<typename I>
 struct contiguous_iterator_impl<I, true>
     : conjunction<
-#if __cplusplus < 202002L
+#if !PREVIEW_STD_HAVE_CXX20_ITERATOR
         disjunction<
 #endif
             derived_from<ITER_CONCEPT<I>, contiguous_iterator_tag>,
-#if __cplusplus < 202002L
+#if !PREVIEW_STD_HAVE_CXX20_ITERATOR
             conjunction<
               derived_from<ITER_CONCEPT<I>, random_access_iterator_tag>,
               LegacyRandomAccessIterator<I>

--- a/include/preview/__ranges/owning_view.h
+++ b/include/preview/__ranges/owning_view.h
@@ -105,21 +105,6 @@ class owning_view : public view_interface<owning_view<R>> {
   R r_;
 };
 
-#if 17 <= PREVIEW_CXX_VERSION && PREVIEW_CXX_VERSION < 20
-
-template<typename R>
-owning_view(R&&)
-    -> owning_view<
-            std::enable_if_t<conjunction<
-                range <std::remove_reference_t<R>>,
-                movable <std::remove_reference_t<R>>,
-                negation<is_initializer_list<R>>
-            >::value,
-        std::remove_reference_t<R>>
-    >;
-
-#endif
-
 } // namespace ranges
 } // namespace namespace preview
 

--- a/include/preview/__ranges/owning_view.h
+++ b/include/preview/__ranges/owning_view.h
@@ -105,10 +105,18 @@ class owning_view : public view_interface<owning_view<R>> {
   R r_;
 };
 
-#if __cplusplus >= 201703L
+#if 17 <= PREVIEW_CXX_VERSION && PREVIEW_CXX_VERSION < 20
 
 template<typename R>
-owning_view(R&&) -> owning_view<R>;
+owning_view(R&&)
+    -> owning_view<
+            std::enable_if_t<conjunction<
+                range <std::remove_reference_t<R>>,
+                movable <std::remove_reference_t<R>>,
+                negation<is_initializer_list<R>>
+            >::value,
+        std::remove_reference_t<R>>
+    >;
 
 #endif
 

--- a/include/preview/__ranges/range_adaptor_closure.h
+++ b/include/preview/__ranges/range_adaptor_closure.h
@@ -38,6 +38,13 @@ struct basic_range {
   unsigned char data_;
 };
 
+struct ubiq_range {
+  ubiq_range() = default;
+
+  template<typename T, std::enable_if_t<range<remove_cvref_t<T>>::value, int> = 0>
+  operator T() const noexcept;
+};
+
 template<typename C, typename D>
 class range_adaptor_closure_object
     : protected compressed_pair<C, D>
@@ -75,7 +82,10 @@ template<typename T>
 struct is_range_adaptor_closure
     : conjunction<
           derived_from_single_crtp<T, range_adaptor_closure>,
-          is_invocable<T, detail::basic_range>,
+          disjunction<
+              is_invocable<T, detail::basic_range>,
+              is_invocable<T, detail::ubiq_range>
+          >,
           negation< range<T> >
       > {};
 

--- a/include/preview/__ranges/range_adaptor_closure.h
+++ b/include/preview/__ranges/range_adaptor_closure.h
@@ -94,6 +94,8 @@ struct range_adaptor_closure {
   static_assert(std::is_object<Derived>::value, "Constraints not satisfied");
   static_assert(same_as<Derived, std::remove_cv_t<Derived>>::value, "Constraints not satisfied");
 
+  using _$preview_derived = Derived;
+
   template<typename Range, typename This, std::enable_if_t<conjunction<
       same_as<Derived, remove_cvref_t<This>>,
       range<remove_cvref_t<Range>>

--- a/include/preview/__ranges/subrange.h
+++ b/include/preview/__ranges/subrange.h
@@ -75,7 +75,7 @@ struct pair_like_convertible_from
     : std::false_type {};
 
 template<typename T, typename U, typename V>
-struct pair_like_convertible_from<T, U, V, false>
+struct pair_like_convertible_from<T, U, V, true>
     : conjunction<
         negation< range<T> >,
         negation< std::is_reference<T> >,

--- a/include/preview/__ranges/subrange.h
+++ b/include/preview/__ranges/subrange.h
@@ -70,42 +70,19 @@ struct make_unsigned_like<T, true> {
 template<typename T>
 using make_unsigned_like_t = typename make_unsigned_like<T>::type;
 
-template<typename T, typename U, typename V, bool = pair_like<T>::value /* true */>
+template<typename T, typename U, typename V, bool = pair_like<T>::value /* false */>
 struct pair_like_convertible_from
-    : conjunction<
-          negation< range<T> >,
-          negation< std::is_reference<T> >,
-          constructible_from<T, U, V>,
-          convertible_to_non_slicing<U, std::tuple_element_t<0, T>>,
-          convertible_to<V, std::tuple_element_t<1, T>>
-      > {};
+    : std::false_type {};
 
 template<typename T, typename U, typename V>
-struct pair_like_convertible_from<T, U, V, false> : std::false_type {};
-
-template<typename R, bool = borrowed_range<R>::value /* true */>
-struct borrowed_range_difference {
-  using type = range_difference_t<R>;
-};
-template<typename R>
-struct borrowed_range_difference<R, false> {};
-template<typename R>
-using borrowed_range_difference_t = typename borrowed_range_difference<R>::type;
-
-template<
-    typename I,
-    typename S = I,
-    subrange_kind K = sized_sentinel_for<S, I>::value ? subrange_kind::sized : subrange_kind::unsized
->
-struct is_subrange_constructible
+struct pair_like_convertible_from<T, U, V, false>
     : conjunction<
-          input_or_output_iterator<I>,
-          sentinel_for<S, I>,
-          disjunction<
-            bool_constant<(K == subrange_kind::sized)>,
-            negation< sized_sentinel_for<S, I> >
-          >
-      > {};
+        negation< range<T> >,
+        negation< std::is_reference<T> >,
+        constructible_from<T, U, V>,
+        convertible_to_non_slicing<U, std::tuple_element_t<0, T>>,
+        convertible_to<V, std::tuple_element_t<1, T>>
+    > {};
 
 template<typename I, typename S, bool Store /* false */>
 struct subrange_size {
@@ -123,18 +100,7 @@ struct subrange_size<I, S, true> {
   std::make_unsigned_t<iter_difference_t<I>> size_ = 0;
 };
 
-template<typename I, typename S, typename R, bool = borrowed_range<R>::value /* true */>
-struct subrange_ctor_range
-    : conjunction<
-          convertible_to_non_slicing<iterator_t<R>, I>,
-          convertible_to<sentinel_t<R>, S>
-      > {};
-
-template<typename I, typename S, typename R>
-struct subrange_ctor_range<I, S, R, false> : std::false_type {};
-
-
-}
+} // namespace detail
 
 template<
     typename I,

--- a/include/preview/__ranges/views/cartesian_product_view.h
+++ b/include/preview/__ranges/views/cartesian_product_view.h
@@ -486,6 +486,13 @@ class cartesian_product_view : public view_interface<cartesian_product_view<Firs
 
   constexpr cartesian_product_view() = default;
 
+  // TODO: Add constraints to the class to block illegal deduction
+  template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+      input_range<First>,
+      forward_range<Vs>...,
+      view<First>,
+      view<Vs>...
+  >::value, int> = 0>
   constexpr cartesian_product_view(First first, Vs... bases)
       : bases_(std::move(first), std::move(bases)...) {}
 

--- a/include/preview/__ranges/views/filter.h
+++ b/include/preview/__ranges/views/filter.h
@@ -23,7 +23,7 @@ namespace detail {
 struct filter_niebloid {
   template<typename R, typename Pred, std::enable_if_t<viewable_range<R>::value, int> = 0>
   constexpr auto operator()(R&& r, Pred&& pred) const {
-    return filter_view<all_t<R>, remove_cvref_t<Pred>>(std::forward<R>(r), std::forward<Pred>(pred));
+    return filter_view<all_t<R>, std::decay_t<Pred>>{std::forward<R>(r), std::forward<Pred>(pred)};
   }
 
   template<typename Pred>

--- a/include/preview/__ranges/views/iota_view.h
+++ b/include/preview/__ranges/views/iota_view.h
@@ -442,6 +442,21 @@ class iota_view : public view_interface<iota_view<W, Bound>> {
   Bound bound_ = Bound();
 };
 
+#if PREVIEW_CXX_VERSION >= 17
+
+template<typename W, typename Bound>
+iota_view(W, Bound)
+    -> iota_view<
+        std::enable_if_t<
+        disjunction<
+            negation<is_integer_like<W>>,
+            negation<is_integer_like<Bound>>,
+            bool_constant<is_signed_integer_like<W>::value == is_signed_integer_like<Bound>::value>
+        >::value, W>,
+        Bound>;
+
+#endif
+
 namespace views {
 namespace detail {
 

--- a/include/preview/__ranges/views/iota_view.h
+++ b/include/preview/__ranges/views/iota_view.h
@@ -36,6 +36,7 @@
 #include "preview/__type_traits/type_identity.h"
 #include "preview/__type_traits/void_t.h"
 #include "preview/__utility/cxx20_rel_ops.h"
+#include "preview/__utility/to_unsigned_like.h"
 
 namespace preview {
 namespace ranges {
@@ -410,19 +411,13 @@ class iota_view : public view_interface<iota_view<W, Bound>> {
   }
 
  private:
-  template<typename T>
-  static constexpr auto to_unsigned_like(T x) {
-    using R = std::make_unsigned_t<T>;
-    return static_cast<R>(x);
-  }
-
   constexpr auto size_impl(std::true_type) const {
     return (value_ < 0)
         ? ((bound_ < 0)
-            ? to_unsigned_like(-value_) - to_unsigned_like(-bound_)
-            : to_unsigned_like(bound_) + to_unsigned_like(-value_)
+            ? preview::to_unsigned_like(-value_) - preview::to_unsigned_like(-bound_)
+            : preview::to_unsigned_like(bound_) + preview::to_unsigned_like(-value_)
           )
-        : to_unsigned_like(bound_) - to_unsigned_like(value_);
+        : preview::to_unsigned_like(bound_) - preview::to_unsigned_like(value_);
   }
   constexpr auto size_impl(std::false_type) const {
     return static_cast<std::size_t>(bound_ - value_);

--- a/include/preview/__ranges/views/iota_view.h
+++ b/include/preview/__ranges/views/iota_view.h
@@ -462,8 +462,8 @@ namespace detail {
 
 struct iota_niebloid {
   template<typename W>
-  constexpr iota_view<std::remove_reference_t<W>> operator()(W&& value) const {
-    return ranges::iota_view<std::remove_reference_t<W>>(std::forward<W>(value));
+  constexpr auto operator()(W&& value) const {
+    return iota_view<std::decay_t<W>>{std::forward<W>(value)};
   }
 
   template<typename W, typename Bound, std::enable_if_t<conjunction<
@@ -473,9 +473,8 @@ struct iota_niebloid {
       bool_constant<is_signed_integer_like<std::remove_reference_t<W>>::value == is_signed_integer_like<std::remove_reference_t<Bound>>::value>
     >
   >::value, int> = 0>
-  constexpr ranges::iota_view<std::remove_reference_t<W>, std::remove_reference_t<Bound>>
-  operator()(W&& value, Bound&& bound) const {
-    return ranges::iota_view<std::remove_reference_t<W>, std::remove_reference_t<Bound>>(std::forward<W>(value), std::forward<Bound>(bound));
+  constexpr auto operator()(W&& value, Bound&& bound) const {
+    return ranges::iota_view<std::decay_t<W>, std::decay_t<Bound>>{std::forward<W>(value), std::forward<Bound>(bound)};
   }
 };
 

--- a/include/preview/__ranges/views/join_view.h
+++ b/include/preview/__ranges/views/join_view.h
@@ -19,12 +19,14 @@
 #include "preview/__iterator/iter_move.h"
 #include "preview/__iterator/iter_swap.h"
 #include "preview/__memory/addressof.h"
+#include "preview/optional.h"
 #include "preview/__ranges/bidirectional_range.h"
 #include "preview/__ranges/common_range.h"
 #include "preview/__ranges/simple_view.h"
 #include "preview/__ranges/forward_range.h"
 #include "preview/__ranges/input_range.h"
 #include "preview/__ranges/movable_box.h"
+#include "preview/__ranges/non_propagating_cache.h"
 #include "preview/__ranges/range_difference_t.h"
 #include "preview/__ranges/range_reference_t.h"
 #include "preview/__ranges/sentinel_t.h"
@@ -42,6 +44,11 @@
 namespace preview {
 namespace ranges {
 namespace detail {
+
+template <class T>
+constexpr T& as_lvalue(T&& x) noexcept {
+  return static_cast<T&>(x);
+}
 
 template<typename Base>
 using join_view_iterator_concept =
@@ -92,26 +99,97 @@ struct join_view_iterator_category<Base, forward_iterator_tag> {
       >;
 };
 
+template<typename Base, typename OuterIter, bool Present = forward_range<Base>::value /* true */>
+struct join_view_iterator_outer_iter {
+  join_view_iterator_outer_iter() = default;
+
+  explicit join_view_iterator_outer_iter(OuterIter outer)
+      : outer_(std::move(outer)) {}
+
+  template<typename Parent>
+  constexpr OuterIter& outer(Parent&) {
+    return outer_;
+  }
+
+  template<typename Parent>
+  constexpr const OuterIter& outer(Parent&) const {
+    return outer_;
+  }
+
+  OuterIter outer_ = OuterIter();
+};
+
+template<typename Base, typename OuterIter>
+struct join_view_iterator_outer_iter<Base, OuterIter, false> {
+  join_view_iterator_outer_iter() = default;
+
+  explicit join_view_iterator_outer_iter(OuterIter) {}
+
+  template<typename Parent>
+  constexpr OuterIter& outer(Parent& p) {
+    return *p->outer_;
+  }
+
+  template<typename Parent>
+  constexpr const OuterIter& outer(Parent& p) const {
+    return *p->outer_;
+  }
+};
+
+template<typename JoinView, typename V, bool UseCache = negation<forward_range<V>>::value /* true */>
+class join_view_outer_base : public view_interface<JoinView> {
+ public:
+
+
+
+ protected:
+  non_propagating_cache<iterator_t<V>> outer_;
+};
+
+template<typename JoinView, typename V>
+class join_view_outer_base<JoinView, V, false> : public view_interface<JoinView> {
+ public:
+
+};
+
+template<typename JoinView, typename V, bool UseCache = negation<std::is_reference<range_reference_t<V>>>::value /* true */>
+class join_view_inner_base : public join_view_outer_base<JoinView, V> {
+ public:
+
+ protected:
+  non_propagating_cache<std::remove_cv_t<range_reference_t<V>>> inner_;
+};
+
+template<typename JoinView, typename V>
+class join_view_inner_base<JoinView, V, false> : public join_view_outer_base<JoinView, V> {
+ public:
+};
+
 } // namespace detail
 
 template<typename V>
-class join_view : public view_interface<join_view<V>> {
- public:
-  static_assert(input_range<V>::value, "Constraints not satisfied");
-  static_assert(view<V>::value, "Constraints not satisfied");
-  static_assert(input_range<range_reference_t<V>>::value, "Constraints not satisfied");
-
+class join_view : public detail::join_view_inner_base<join_view<V>, V> {
  private:
   template <bool Const>
   using InnerRng = range_reference_t<maybe_const<Const, V>>;
 
  public:
+  static_assert(input_range<V>::value, "Constraints not satisfied");
+  static_assert(view<V>::value, "Constraints not satisfied");
+  static_assert(input_range<range_reference_t<V>>::value, "Constraints not satisfied");
+
   template<bool Const> class iterator;
   template<bool Const> friend class iterator;
   template<bool Const> class sentinel;
 
   template<bool Const>
-  class iterator : detail::join_view_iterator_category<maybe_const<Const, V>> {
+  class iterator
+      : public detail::join_view_iterator_category<maybe_const<Const, V>>
+      , private detail::join_view_iterator_outer_iter<
+            maybe_const<Const, V>, // Base
+            iterator_t<maybe_const<Const, V>> // OuterIter
+        >
+  {
     using Parent = maybe_const<Const, join_view>;
     using Base = maybe_const<Const, V>;
     using OuterIter = iterator_t<Base>;
@@ -120,6 +198,71 @@ class join_view : public view_interface<join_view<V>> {
 
     friend class join_view;
     template<bool> friend class sentinel;
+
+    using outer_iter_base = detail::join_view_iterator_outer_iter<
+        maybe_const<Const, V>,
+        iterator_t<maybe_const<Const, V>>
+    >;
+
+    constexpr OuterIter& outer() {
+      return outer_iter_base::outer(parent_);
+    }
+
+    constexpr const OuterIter& outer() const {
+      return outer_iter_base::outer(parent_);
+    }
+
+    constexpr decltype(auto) update_inner_impl(const iterator_t<Base>& x, std::true_type /* ref_is_glvalue */) {
+      return *x;
+    }
+    constexpr decltype(auto) update_inner_impl(const iterator_t<Base>& x, std::false_type /* ref_is_glvalue */) {
+      return parent_->inner_.emplace_deref(x);
+    }
+
+    constexpr decltype(auto) update_inner(const iterator_t<Base>& x) {
+      return update_inner_impl(x, bool_constant<ref_is_glvalue>{});
+    }
+
+    constexpr void satisfy_impl(std::true_type /* ref_is_glvalue */) {
+      for (; outer() != ranges::end(parent_->base_); ++outer()) {
+        auto&& inner = update_inner(outer());
+        inner_ = ranges::begin(inner);
+        if (*inner_ != ranges::end(inner))
+          return;
+      }
+      inner_.reset();
+    }
+    constexpr void satisfy_impl(std::false_type /* ref_is_glvalue */) {
+      for (; outer() != ranges::end(parent_->base_); ++outer()) {
+        auto&& inner = update_inner(outer());;
+        inner_ = ranges::begin(inner);
+        if (inner_ != ranges::end(inner))
+          return;
+      }
+    }
+
+    constexpr void satisfy() {
+      satisfy_impl(bool_constant<ref_is_glvalue>{});
+    }
+
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        forward_range<Base>
+    >::value, int> = 0>
+    constexpr iterator(Parent& parent, OuterIter outer)
+        : outer_iter_base(std::move(outer))
+        , parent_(preview::addressof(parent))
+    {
+      satisfy();
+    }
+
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        negation<forward_range<Base>>
+    >::value, int> = 0>
+    constexpr explicit iterator(Parent& parent)
+        : parent_(preview::addressof(parent))
+    {
+      satisfy();
+    }
 
    public:
     using iterator_concept = detail::join_view_iterator_concept<Base>;
@@ -131,18 +274,7 @@ class join_view : public view_interface<join_view<V>> {
     using reference = decltype(**std::declval<movable_box<InnerIter>&>());
 #endif
 
-    template<typename O = OuterIter, std::enable_if_t<conjunction<
-        default_initializable<O>,
-        default_initializable<InnerIter>
-    >::value, int> = 0>
-    iterator()
-        : outer_(), inner_(), parent_(nullptr) {}
-
-    constexpr iterator(Parent& parent, OuterIter outer)
-        : outer_(std::move(outer)), parent_(preview::addressof(parent))
-    {
-      satisfy();
-    }
+    iterator() = default;
 
     template<bool AntiConst, std::enable_if_t<conjunction<
         bool_constant<((Const != AntiConst) && Const)>,
@@ -150,51 +282,56 @@ class join_view : public view_interface<join_view<V>> {
         convertible_to<iterator_t<InnerRng<false>>, InnerIter>
     >::value, int> = 0>
     constexpr iterator(iterator<AntiConst> i)
-        : outer_(std::move(i.outer_)), inner_(std::move(i.inner_)), parent_(i.parent_) {}
+        : outer_iter_base(std::move(i.outer()))
+        , inner_(std::move(i.inner_))
+        , parent_(i.parent_) {}
 
     constexpr decltype(auto) operator*() const {
       return **inner_;
     }
 
-    template<typename II = InnerIter, std::enable_if_t<conjunction<
-        has_operator_arrow<II>,
-        copyable<II>
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        has_operator_arrow<InnerIter>,
+        copyable<InnerIter>
     >::value, int> = 0>
     constexpr decltype(auto) operator->() const {
       return *inner_;
     }
 
-    template<bool B = ref_is_glvalue, std::enable_if_t<B, int> = 0>
     constexpr iterator& operator++() {
-      auto&& inner_rng = *outer_;
-      if (++*inner_ == ranges::end(inner_rng)) {
-        ++outer_;
+      return pre_increment(bool_constant<ref_is_glvalue>{});
+    }
+
+   private:
+    constexpr iterator& pre_increment(std::true_type) {
+      if (++*inner_ == ranges::end(detail::as_lvalue(*outer()))) {
+        ++outer();
+        satisfy();
+      }
+      return *this;
+    }
+    constexpr iterator& pre_increment(std::false_type) {
+      if (++*inner_ == ranges::end(detail::as_lvalue(*parent_->inner_))) {
+        ++outer();
         satisfy();
       }
       return *this;
     }
 
-    template<bool B = ref_is_glvalue, std::enable_if_t<B == false, int> = 0>
-    constexpr iterator& operator++() {
-      auto&& inner_rng = *parent_->inner_;
-      if (++*inner_ == ranges::end(inner_rng)) {
-        ++outer_;
-        satisfy();
-      }
-      return *this;
-    }
-
-    template<bool B = ref_is_glvalue, std::enable_if_t<conjunction<
-        bool_constant<B>,
-        forward_range<Base>,
-        forward_range<range_reference_t<Base>>
-    >::value == false, int> = 0>
+   public:
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        negation<conjunction<
+            bool_constant<ref_is_glvalue>,
+            forward_range<Base>,
+            forward_range<range_reference_t<Base>>
+        >>
+    >::value, int> = 0>
     constexpr void operator++(int) {
       ++*this;
     }
 
-    template<bool B = ref_is_glvalue, std::enable_if_t<conjunction<
-        bool_constant<B>,
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        bool_constant<ref_is_glvalue>,
         forward_range<Base>,
         forward_range<range_reference_t<Base>>
     >::value, int> = 0>
@@ -204,23 +341,23 @@ class join_view : public view_interface<join_view<V>> {
       return tmp;
     }
 
-    template<bool B = ref_is_glvalue, std::enable_if_t<conjunction<
-        bool_constant<B>,
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        bool_constant<ref_is_glvalue>,
         bidirectional_range<Base>,
         bidirectional_range<range_reference_t<Base>>,
         common_range<range_reference_t<Base>>
     >::value, int> = 0>
     constexpr iterator& operator--() {
-      if (outer_ == ranges::end(parent_->base_))
-        inner_ = ranges::end(*--outer_);
-      while (*inner_ == ranges::begin(*outer_))
-        inner_ = ranges::end(*--outer_);
+      if (outer() == ranges::end(parent_->base_))
+        inner_ = ranges::end(detail::as_lvalue(*--outer()));
+      while (*inner_ == ranges::begin(detail::as_lvalue(*outer())))
+        inner_ = ranges::end(detail::as_lvalue(*--outer()));
       --*inner_;
       return *this;
     }
 
-    template<bool B = ref_is_glvalue, std::enable_if_t<conjunction<
-        bool_constant<B>,
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        bool_constant<ref_is_glvalue>,
         bidirectional_range<Base>,
         bidirectional_range<range_reference_t<Base>>,
         common_range<range_reference_t<Base>>
@@ -231,22 +368,18 @@ class join_view : public view_interface<join_view<V>> {
       return tmp;
     }
 
-    constexpr void satisfy() {
-      satisfy_impl(bool_constant<ref_is_glvalue>{});
-    }
-
-    template<bool B = ref_is_glvalue, std::enable_if_t<conjunction<
-        bool_constant<B>,
-        equality_comparable<iterator_t<Base>>,
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        bool_constant<ref_is_glvalue>,
+        forward_range<Base>,
         equality_comparable<iterator_t<range_reference_t<Base>>>
     >::value, int> = 0>
     friend constexpr bool operator==(const iterator& x, const iterator& y) {
-      return (x.outer_ == y.outer_) && (*x.inner_ == *y.inner_);
+      return (x.outer_ == y.outer_) && (x.inner_ == y.inner_);
     }
 
-    template<bool B = ref_is_glvalue, std::enable_if_t<conjunction<
-        bool_constant<B>,
-        equality_comparable<iterator_t<Base>>,
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        bool_constant<ref_is_glvalue>,
+        forward_range<Base>,
         equality_comparable<iterator_t<range_reference_t<Base>>>
     >::value, int> = 0>
     friend constexpr bool operator!=(const iterator& x, const iterator& y) {
@@ -259,66 +392,19 @@ class join_view : public view_interface<join_view<V>> {
       return ranges::iter_move(*i.inner_);
     }
 
-    template<typename II = InnerIter, std::enable_if_t<indirectly_swappable<II>::value, int> = 0>
+    template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+        indirectly_swappable<InnerIter>
+    >::value, int> = 0>
     friend constexpr void iter_swap(const iterator& x, const iterator& y)
         noexcept(noexcept(ranges::iter_swap(*x.inner_, *y.inner_)))
     {
-      ranges::iter_swap(x.inner_, y.inner_);
+      ranges::iter_swap(*x.inner_, *y.inner_);
     }
 
    private:
-    constexpr OuterIter& get_outer() noexcept {
-      return get_outer(forward_range<Base>{});
-    }
-    constexpr const OuterIter& get_outer() const noexcept {
-      return get_outer(forward_range<Base>{});
-    }
-    constexpr OuterIter& get_outer_impl(std::true_type /* forward_range */) noexcept {
-        return outer_;
-    }
-    constexpr OuterIter& get_outer_impl(std::false_type /* forward_range */) noexcept {
-        return *parent_->outer_;
-    }
-    constexpr OuterIter& get_outer_impl(std::true_type /* forward_range */) const noexcept {
-        return outer_;
-    }
-    constexpr OuterIter& get_outer_impl(std::false_type /* forward_range */) const noexcept {
-        return *parent_->outer_;
-    }
 
-    constexpr decltype(auto) update_inner_impl(const iterator_t<Base>& x, std::true_type /* ref_is_glvalue */) {
-      return *x;
-    }
-    constexpr decltype(auto) update_inner_impl(const iterator_t<Base>& x, std::false_type /* ref_is_glvalue */) {
-      return parent_->inner_.emplace(x);
-    }
-
-    constexpr decltype(auto) update_inner(const iterator_t<Base>& x) {
-      return update_inner_impl(x, bool_constant<ref_is_glvalue>{});
-    }
-
-    constexpr void satisfy_impl(std::true_type /* ref_is_glvalue */) {
-      for (; outer_ != ranges::end(parent_->base_); ++outer_) {
-        auto&& inner = update_inner(outer_);
-        inner_ = ranges::begin(inner);
-        if (*inner_ != ranges::end(inner))
-          return;
-      }
-
-      inner_ = InnerIter();
-    }
-    constexpr void satisfy_impl(std::false_type /* ref_is_glvalue */) {
-      for (; outer_ != ranges::end(parent_->base_); ++outer_) {
-        auto&& inner = update_inner(outer_);;
-        inner_ = ranges::begin(inner);
-        if (inner_ != ranges::end(inner))
-          return;
-      }
-    }
-
-    OuterIter outer_;
-    movable_box<InnerIter> inner_;
-    Parent* parent_;
+    optional<InnerIter> inner_;
+    Parent* parent_ = nullptr;
   };
 
   template<bool Const>
@@ -339,33 +425,46 @@ class join_view : public view_interface<join_view<V>> {
     constexpr sentinel(sentinel<AntiConst> s)
         : end_(std::move(s.end_)) {}
 
-    friend constexpr bool operator==(const iterator<Const>& x, const sentinel& y) {
-      using namespace preview::rel_ops;
-      return x.get_outer() == y.end_;
+    template<bool OtherConst, std::enable_if_t<
+        sentinel_for<sentinel_t<Base>, iterator_t<maybe_const<OtherConst, V>>>
+    ::value, int> = 0>
+    friend constexpr bool operator==(const iterator<OtherConst>& x, const sentinel& y) {
+      return x.outer() == y.end_;
     }
 
-    friend constexpr bool operator==(const sentinel& y, const iterator<Const>& x) {
-      return x == y;
-    }
-
-    friend constexpr bool operator!=(const iterator<Const>& x, const sentinel& y) {
+    template<bool OtherConst, std::enable_if_t<
+        sentinel_for<sentinel_t<Base>, iterator_t<maybe_const<OtherConst, V>>>
+    ::value, int> = 0>
+    friend constexpr bool operator!=(const iterator<OtherConst>& x, const sentinel& y) {
       return !(x == y);
     }
 
-    friend constexpr bool operator!=(const sentinel& y, const iterator<Const>& x) {
+    template<bool OtherConst, std::enable_if_t<
+        sentinel_for<sentinel_t<Base>, iterator_t<maybe_const<OtherConst, V>>>
+    ::value, int> = 0>
+    friend constexpr bool operator==(const sentinel& y, const iterator<OtherConst>& x) {
+      return x == y;
+    }
+
+    template<bool OtherConst, std::enable_if_t<
+        sentinel_for<sentinel_t<Base>, iterator_t<maybe_const<OtherConst, V>>>
+    ::value, int> = 0>
+    friend constexpr bool operator!=(const sentinel& y, const iterator<OtherConst>& x) {
       return !(x == y);
     }
 
    private:
-    sentinel_t<Base> end_;
+    sentinel_t<Base> end_{};
   };
 
-  template<typename V2 = V, std::enable_if_t<default_initializable<V2>::value, int> = 0>
-  join_view() : base_(V()) {}
+  join_view() = default;
 
-  constexpr explicit join_view(V base) : base_(std::move(base)) {}
+  constexpr explicit join_view(V base)
+      : base_(std::move(base)) {}
 
-  template<typename V2 = V, std::enable_if_t<copy_constructible<V2>::value, int> = 0>
+  template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+      copy_constructible<V>
+  >::value, int> = 0>
   constexpr V base() const& {
     return base_;
   }
@@ -374,41 +473,40 @@ class join_view : public view_interface<join_view<V>> {
     return std::move(base_);
   }
 
+  // vvvvvvvvvv begin vvvvvvvvvv
   constexpr auto begin() {
-    using B = conjunction<simple_view<V>, std::is_reference<range_reference_t<V>>>;
-    return iterator<B::value>{*this, ranges::begin(base_)};
+    return begin_impl(forward_range<V>{});
   }
 
-  template<typename V2 = V, std::enable_if_t<conjunction<
-      input_range<const V2>,
-      std::is_reference<range_reference_t<const V2>>
+ private:
+  constexpr auto begin_impl(std::true_type /* forward_range<V> */) {
+    using B = conjunction<simple_view<V>, std::is_reference<InnerRng<false>>>;
+    return iterator<B::value>{*this, ranges::begin(base_)};
+  }
+  constexpr auto begin_impl(std::false_type /* forward_range<V> */) {
+    this->outer_ = ranges::begin(base_);
+    return iterator<false>{*this};
+  }
+  // ^^^^^^^^^^ begin ^^^^^^^^^^
+
+ public:
+  template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+      forward_range<const V>,
+      std::is_reference<range_reference_t<const V>>,
+      input_range<range_reference_t<const V>>
   >::value, int> = 0>
   constexpr auto begin() const {
     return iterator<true>{*this, ranges::begin(base_)};
   }
 
+  // vvvvvvvvvv end() vvvvvvvvvv
+
   constexpr auto end() {
     return end_impl(conjunction<
         forward_range<V>,
-        std::is_reference<range_reference_t<V>>,
-        forward_range<range_reference_t<V>>,
-        common_range<V>,
-        common_range<range_reference_t<V>>
-      >{});
-  }
-
-  template<typename V2 = V, std::enable_if_t<conjunction<
-      input_range<const V2>,
-      std::is_reference<range_reference_t<const V2>>
-  >::value, int> = 0>
-  constexpr auto end() const {
-    return end_impl(conjunction<
-        forward_range<const V>,
-        std::is_reference<range_reference_t<const V>>,
-        forward_range<range_reference_t<const V>>,
-        common_range<const V>,
-        common_range<range_reference_t<const V>>
-      >{});
+        std::is_reference<InnerRng<false>>, forward_range<InnerRng<false>>,
+        common_range<V>, common_range<InnerRng<false>>
+    >{});
   }
 
  private:
@@ -418,15 +516,33 @@ class join_view : public view_interface<join_view<V>> {
   constexpr auto end_impl(std::false_type) {
     return sentinel<simple_view<V>::value>{*this};
   }
+  // ^^^^^^^^^^ end() ^^^^^^^^^^
 
+  // vvvvvvvvvv end() const vvvvvvvvvv
+ public:
+  template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+      forward_range<const V>,
+      std::is_reference<range_reference_t<const V>>,
+      input_range<range_reference_t<const V>>
+  >::value, int> = 0>
+  constexpr auto end() const {
+    return end_impl(conjunction<
+        forward_range<range_reference_t<const V>>,
+        common_range<const V>,
+        common_range<range_reference_t<const V>>
+    >{});
+  }
+
+ private:
   constexpr auto end_impl(std::true_type) const {
     return iterator<true>{*this, ranges::end(base_)};
   }
   constexpr auto end_impl(std::false_type) const {
     return sentinel<true>{*this};
   }
+  // ^^^^^^^^^^ end() const ^^^^^^^^^^
 
-  V base_;
+  V base_{};
 };
 
 #if __cplusplus >= 201703L

--- a/include/preview/__ranges/views/repeat.h
+++ b/include/preview/__ranges/views/repeat.h
@@ -29,8 +29,7 @@ struct repeat_niebloid {
       std::is_object< remove_cvref_t<W> >
   >::value, int> = 0>
   constexpr auto operator()(W&& value) const {
-    using RV = repeat_view<remove_cvref_t<W>>;
-    return RV(std::forward<W>(value));
+    return repeat_view<std::decay_t<W>>{std::forward<W>(value)};
   }
 
   template<typename W, typename Bound, std::enable_if_t<conjunction<
@@ -42,8 +41,7 @@ struct repeat_niebloid {
       >
   >::value, int> = 0>
   constexpr auto operator()(W&& value, Bound&& bound) const {
-    using RV = repeat_view<remove_cvref_t<W>, remove_cvref_t<Bound>>;
-    return RV(std::forward<W>(value), std::forward<Bound>(bound));
+    return repeat_view<std::decay_t<W>, std::decay_t<Bound>>{std::forward<W>(value), std::forward<Bound>(bound)};
   }
 };
 

--- a/include/preview/__ranges/views/split.h
+++ b/include/preview/__ranges/views/split.h
@@ -8,62 +8,15 @@
 #include <type_traits>
 #include <utility>
 
-#include "split_view.h"
-#include "preview/__concepts/different_from.h"
 #include "preview/__core/inline_variable.h"
-#include "preview/__ranges/movable_box.h"
-#include "preview/__ranges/range_adaptor_closure.h"
-#include "preview/__ranges/range_value_t.h"
+#include "preview/__ranges/range_adaptor.h"
 #include "preview/__ranges/viewable_range.h"
-#include "preview/__ranges/views/all.h"
-#include "preview/__ranges/views/single.h"
 #include "preview/__ranges/views/split_view.h"
 
 namespace preview {
 namespace ranges {
 namespace views {
 namespace detail {
-
-template<typename Pattern>
-class split_adapter_closure : public range_adaptor_closure<split_adapter_closure<Pattern>> {
-  template<typename R, bool = ranges::detail::same_with_range_value<R, Pattern>::value /* true */>
-  struct pattern_type_impl {
-    using type = single_view<range_value_t<R>>;
-  };
-  template<typename R>
-  struct pattern_type_impl<R, false> {
-    using type = all_t<Pattern>;
-  };
-
-  template<typename R>
-  using pattern_type = typename pattern_type_impl<R>::type;
-  movable_box<Pattern> pattern_;
-
- public:
-  template<typename T, std::enable_if_t<different_from<T, split_adapter_closure>::value, int> = 0>
-  constexpr explicit split_adapter_closure(T&& pattern)
-      : pattern_(std::forward<T>(pattern)) {}
-
-  template<typename R, std::enable_if_t<range<R>::value, int> = 0>
-  constexpr auto operator()(R&& r) & {
-    return split_view<all_t<R>, pattern_type<R>>(std::forward<R>(r), *pattern_);
-  }
-
-  template<typename R, std::enable_if_t<range<R>::value, int> = 0>
-  constexpr auto operator()(R&& r) const& {
-    return split_view<all_t<R>, pattern_type<R>>(std::forward<R>(r), *pattern_);
-  }
-
-  template<typename R, std::enable_if_t<range<R>::value, int> = 0>
-  constexpr auto operator()(R&& r) && {
-    return split_view<all_t<R>, pattern_type<R>>(std::forward<R>(r), std::move(*pattern_));
-  }
-
-  template<typename R, std::enable_if_t<range<R>::value, int> = 0>
-  constexpr auto operator()(R&& r) const && {
-    return split_view<all_t<R>, pattern_type<R>>(std::forward<R>(r), std::move(*pattern_));
-  }
-};
 
 struct split_niebloid {
   template<typename R, typename Pattern, std::enable_if_t<viewable_range<R>::value, int> = 0>
@@ -72,8 +25,8 @@ struct split_niebloid {
   }
 
   template<typename Pattern>
-  constexpr split_adapter_closure<std::remove_reference_t<Pattern>> operator()(Pattern&& pattern) const {
-    return split_adapter_closure<std::remove_reference_t<Pattern>>(std::forward<Pattern>(pattern));
+  constexpr auto operator()(Pattern&& pattern) const {
+    return range_adaptor<split_niebloid, std::decay_t<Pattern>>{std::forward<Pattern>(pattern)};
   }
 };
 

--- a/include/preview/__ranges/views/take.h
+++ b/include/preview/__ranges/views/take.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 
 #include "preview/__core/decay_copy.h"
+#include "preview/__core/std_version.h"
 #include "preview/__concepts/convertible_to.h"
 #include "preview/__ranges/begin.h"
 #include "preview/__ranges/end.h"
@@ -26,11 +27,19 @@
 #include "preview/__ranges/views/take_view.h"
 #include "preview/span.h"
 #include "preview/string_view.h"
+#include "preview/__type_traits/conditional.h"
 #include "preview/__type_traits/detail/return_category.h"
 #include "preview/__type_traits/is_specialization.h"
 #include "preview/__type_traits/negation.h"
 #include "preview/__type_traits/remove_cvref.h"
 #include "preview/__type_traits/type_identity.h"
+
+#if PREVIEW_CXX_VERSION >= 17
+#include <string_view>
+#endif
+#if PREVIEW_CXX_VERSION >= 20
+#include <span>
+#endif
 
 namespace preview {
 namespace ranges {
@@ -54,21 +63,27 @@ struct take_niebloid {
     return ((void)count, preview_decay_copy(std::forward<R>(r)));
   }
 
-  template<typename T>
-  struct is_span : std::false_type {};
-  template<typename T, std::size_t Extent>
-  struct is_span<span<T, Extent>> : std::true_type {};
-
-  template<typename T, typename D, bool = is_span<T>::value /* true */>
-  struct return_category_span : std::true_type {
-    using category = return_category<2, span<typename T::element_type>>;
-  };
   template<typename T, typename D>
-  struct return_category_span<T, D, false> : std::false_type {
+  struct return_category_span : std::false_type {
     using category = return_category<0>;
   };
+  template<typename U, std::size_t Extent, typename D>
+  struct return_category_span<span<U, Extent>, D> : std::true_type {
+    using category = return_category<2, span<U>>;
+  };
+#if PREVIEW_CXX_VERSION >= 20
+  template<typename U, std::size_t Extent, typename D>
+  struct return_category_span<std::span<U, Extent>, D> : std::true_type {
+    using category = return_category<2, std::span<U>>;
+  };
+#endif
 
-  template<typename T, bool = is_specialization<T, basic_string_view>::value /* true */>
+  template<typename T, bool = disjunction<
+      is_specialization<T, basic_string_view>
+#if PREVIEW_CXX_VERSION >= 17
+      , is_specialization<T, std::basic_string_view>
+#endif
+  >::value /* true */>
   struct return_category_string_view : std::true_type {
     using category = return_category<2, T>;
   };
@@ -77,7 +92,7 @@ struct take_niebloid {
     using category = return_category<0>;
   };
 
-  template<typename T, bool = ranges::detail::is_subrange<T>::value /* true */>
+  template<typename T, bool = conjunction<ranges::detail::is_subrange<T>, random_access_range<T>, sized_range<T>>::value /* true */>
   struct return_category_subrange : std::true_type {
     using category = return_category<2, subrange<iterator_t<T>>>;
   };
@@ -103,8 +118,8 @@ struct take_niebloid {
   struct return_category_iota_view<T, false> : std::false_type {
     using category = return_category<0>;
   };
-  template<typename R, typename IV>
-  constexpr IV operator()(R&& e, ranges::range_difference_t<R> f, return_category<3, IV>) const {
+  template<typename R, typename T>
+  constexpr auto operator()(R&& e, ranges::range_difference_t<R> f, return_category<3, T /* unused */>) const {
     using D = ranges::range_difference_t<decltype((e))>;
     return views::iota(
         *ranges::begin(e),
@@ -138,21 +153,15 @@ struct take_niebloid {
 
   template<typename R, typename T, typename D>
   using category =
-      std::conditional_t<
-          return_category_empty_view<R, T, D>::value, typename return_category_empty_view<R, T, D>::category, // 1
-      std::conditional_t<
-          return_category_span<T, D>::value, typename return_category_span<T, D>::category, // 2
-      std::conditional_t<
-          return_category_string_view<T>::value, typename return_category_string_view<T>::category, // 2
-      std::conditional_t<
-          return_category_subrange<T>::value, typename return_category_subrange<T>::category, // 2
-      std::conditional_t<
-          return_category_iota_view<T>::value, typename return_category_iota_view<T>::category, // 3
-      std::conditional_t<
-          return_category_repeat_view<T>::value, typename return_category_repeat_view<T>::category, // 4
-          return_category<5, take_view<views::all_t<R>>>> // 5
-      >>>>>;
-
+      conditional_t<
+          return_category_empty_view<R, T, D>, typename return_category_empty_view<R, T, D>::category, // 1
+          return_category_span<T, D>, typename return_category_span<T, D>::category, // 2
+          return_category_string_view<T>, typename return_category_string_view<T>::category, // 2
+          return_category_subrange<T>, typename return_category_subrange<T>::category, // 2
+          return_category_iota_view<T>, typename return_category_iota_view<T>::category, // 3
+          return_category_repeat_view<T>, typename return_category_repeat_view<T>::category, // 4
+          return_category<5, take_view<views::all_t<R>>> // 5
+      >;
 
  public:
   template<typename R, std::enable_if_t<ranges::viewable_range<R>::value, int> = 0>

--- a/include/preview/__tuple/apply.h
+++ b/include/preview/__tuple/apply.h
@@ -9,25 +9,42 @@
 # include <utility>
 #
 # include "preview/__functional/invoke.h"
+# include "preview/__tuple/tuple_integer_sequence.h"
 
 namespace preview {
 namespace detail {
 
 template<class F, class Tuple, std::size_t... I>
 constexpr inline decltype(auto)
-apply_impl(F&& f, Tuple&& t, std::index_sequence<I...>) {
+apply_impl(F&& f, Tuple&& t, std::index_sequence<I...>)
+    noexcept(noexcept(
+        preview::invoke(
+            std::forward<F>(f),
+            std::get<I>(std::forward<Tuple>(t))...
+        )
+    ))
+{
   return preview::invoke(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...);
 }
 
 } // namespace detail
 
 template<class F, class Tuple>
-constexpr inline
-decltype(auto)
-apply(F&& f, Tuple&& t) {
-  return detail::apply_impl(
-      std::forward<F>(f), std::forward<Tuple>(t),
-      std::make_index_sequence<std::tuple_size<std::remove_reference_t<Tuple>>::value>{});
+constexpr inline decltype(auto)
+apply(F&& f, Tuple&& t)
+    noexcept(noexcept(
+        preview::detail::apply_impl(
+            std::forward<F>(f),
+            std::forward<Tuple>(t),
+            tuple_index_sequence<Tuple>{}
+        )
+    ))
+{
+  return preview::detail::apply_impl(
+      std::forward<F>(f),
+      std::forward<Tuple>(t),
+      tuple_index_sequence<Tuple>{}
+  );
 }
 
 } // namespace preview

--- a/include/preview/__tuple/tuple_for_each.h
+++ b/include/preview/__tuple/tuple_for_each.h
@@ -12,6 +12,7 @@
 
 #include "preview/__functional/invoke.h"
 #include "preview/__utility/in_place.h"
+#include "preview/__tuple/tuple_integer_sequence.h"
 #include "preview/__type_traits/conjunction.h"
 #include "preview/__type_traits/copy_cvref.h"
 #include "preview/__type_traits/is_invocable.h"
@@ -19,9 +20,6 @@
 
 namespace preview {
 namespace detail {
-
-template<typename Tuple>
-using tuple_index_sequence = std::make_index_sequence<std::tuple_size<remove_cvref_t<Tuple>>::value>;
 
 template<typename Tuple, typename F, typename Seq>
 struct tuple_for_each_invocable_impl;
@@ -72,7 +70,7 @@ template<typename Tuple, typename F>
 constexpr std::enable_if_t<detail::tuple_for_each_invocable<Tuple, F>::value>
 tuple_for_each(Tuple&& t, F&& f) {
   return preview::detail::tuple_for_each_impl(
-      detail::tuple_index_sequence<Tuple>{},
+      tuple_index_sequence<Tuple>{},
       std::forward<Tuple>(t),
       std::forward<F>(f)
   );
@@ -83,7 +81,7 @@ template<typename Tuple, typename F>
 constexpr std::enable_if_t<detail::tuple_for_each_in_place_index_invocable<Tuple, F>::value>
 tuple_for_each_index(Tuple&& t, F&& f) {
   return preview::detail::tuple_for_each_index_impl(
-      detail::tuple_index_sequence<Tuple>{},
+      tuple_index_sequence<Tuple>{},
       std::forward<Tuple>(t),
       std::forward<F>(f)
   );

--- a/include/preview/__tuple/tuple_integer_sequence.h
+++ b/include/preview/__tuple/tuple_integer_sequence.h
@@ -1,0 +1,24 @@
+# /*
+#  * Created by YongGyu Lee on 2024/06/23.
+#  */
+#
+# ifndef PREVIEW_TUPLE_TUPLE_INTEGER_SEQUENCE_H_
+# define PREVIEW_TUPLE_TUPLE_INTEGER_SEQUENCE_H_
+#
+# include <cstddef>
+# include <tuple>
+# include <utility>
+#
+# include "preview/__type_traits/remove_cvref.h"
+
+namespace preview {
+
+template<typename T, typename Tuple>
+using tuple_integer_sequence = std::make_integer_sequence<T, std::tuple_size<remove_cvref_t<Tuple>>::value>;
+
+template<typename Tuple>
+using tuple_index_sequence = tuple_integer_sequence<std::size_t, Tuple>;
+
+} // namespace preview
+
+# endif // PREVIEW_TUPLE_TUPLE_INTEGER_SEQUENCE_H_

--- a/include/preview/__tuple/tuple_transform.h
+++ b/include/preview/__tuple/tuple_transform.h
@@ -9,38 +9,21 @@
 #include <utility>
 
 #include "preview/__functional/invoke.h"
+#include "preview/__tuple/apply.h"
 #include "preview/__type_traits/bool_constant.h"
 #include "preview/__type_traits/conjunction.h"
+#include "preview/__type_traits/is_invocable.h"
 #include "preview/__type_traits/remove_cvref.h"
 
 namespace preview {
-namespace detail {
-
-template<typename Tuple, typename F, std::size_t... I>
-constexpr auto tuple_transform_impl(Tuple&& t, F&& f, std::index_sequence<I...>)
-    noexcept(conjunction<
-        bool_constant<noexcept(preview::invoke(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))))>...
-    >::value)
-{
-  return std::tuple<decltype(preview::invoke(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))))...>(
-      preview::invoke(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t)))...);
-}
-
-} // namespace detail
 
 template<typename Tuple, typename F>
-constexpr auto tuple_transform(Tuple&& t, F&& f)
-    noexcept(noexcept(
-        detail::tuple_transform_impl(
-            std::forward<Tuple>(t),
-            std::forward<F>(f),
-            std::make_index_sequence<std::tuple_size<remove_cvref_t<Tuple>>::value>{}
-        )
-    ))
-{
-  return detail::tuple_transform_impl(
-      std::forward<Tuple>(t), std::forward<F>(f),
-      std::make_index_sequence<std::tuple_size<remove_cvref_t<Tuple>>::value>{});
+constexpr auto tuple_transform(Tuple&& t, F&& f) {
+  return preview::apply([&](auto&&... args)
+  {
+    return std::tuple<invoke_result_t<F&, decltype(args)>...>
+        (preview::invoke(f, std::forward<decltype(args)>(args))...);
+  }, std::forward<Tuple>(t));
 }
 
 } // namespace preview

--- a/include/preview/__type_traits/has_conversion_operator.h
+++ b/include/preview/__type_traits/has_conversion_operator.h
@@ -1,0 +1,24 @@
+//
+// Created by YongGyu Lee on 2024. 6. 29.
+//
+
+#ifndef PREVIEW_TYPE_TRAITS_HAS_CONVERSION_OPERATOR_H_
+#define PREVIEW_TYPE_TRAITS_HAS_CONVERSION_OPERATOR_H_
+
+#include <type_traits>
+
+#include "preview/__type_traits/void_t.h"
+
+namespace preview {
+
+template<typename From, typename To, typename = void>
+struct has_conversion_operator
+    : std::false_type {};
+
+template<typename From, typename To>
+struct has_conversion_operator<From, To, void_t<decltype( std::declval<From>().operator To() )>>
+    : std::is_same<decltype( std::declval<From>().operator To() ), To> {};
+
+} // namespace preview
+
+#endif // PREVIEW_TYPE_TRAITS_HAS_CONVERSION_OPERATOR_H_

--- a/include/preview/__utility/cxx20_rel_ops.h
+++ b/include/preview/__utility/cxx20_rel_ops.h
@@ -17,6 +17,7 @@
 // automatically generates comparison operators based on user-defined `operator==` and `operator<` in C++20 way
 
 namespace preview {
+namespace rel_ops {
 namespace detail {
 
 template<typename T, typename U, typename = void>
@@ -36,14 +37,12 @@ struct less_than_comparable_precxx20<
 
 } // namespace detail
 
-namespace rel_ops {
-
 #if __cplusplus < 202002L
 
 // synthesized from `U == T`
 template<typename T, typename U, std::enable_if_t<conjunction<
     negation<std::is_same<T, U>>,
-    preview::detail::equality_comparable_precxx20<const U&, const T&>
+    detail::equality_comparable_precxx20<const U&, const T&>
 >::value, int> = 0>
 constexpr bool operator==(const T& a, const U& b) noexcept(noexcept(b == a)) {
   return b == a;
@@ -82,8 +81,8 @@ struct is_equality_comparable
 template<typename T, typename U, std::enable_if_t<conjunction<
     negation<std::is_same<T, U>>,
     is_equality_comparable<T, U>,
-    negation<preview::detail::less_than_comparable_precxx20<const T&, const U&>>,
-    preview::detail::less_than_comparable_precxx20<const U&, const T&>
+    negation< detail::less_than_comparable_precxx20<const T&, const U&> >,
+    detail::less_than_comparable_precxx20<const U&, const T&>
   >::value, int> = 0>
 constexpr bool operator<(const T& a, const U& b) noexcept(noexcept(!( (b < a) || (a == b)))) {
   // (a < b) -> !(a >= b) -> !( a > b || a == b) -> !( b < a || a == b)

--- a/include/preview/__utility/cxx20_rel_ops.h
+++ b/include/preview/__utility/cxx20_rel_ops.h
@@ -67,14 +67,7 @@ struct is_equality_comparable_impl {
 
 template<typename T, typename U>
 struct is_equality_comparable
-#if (defined(__GNUC__) || defined(__GNUG__)) && !defined(__clang__)
-    : disjunction<
-        detail::equality_comparable_precxx20<T, U>,
-        detail::equality_comparable_precxx20<U, T>
-    > {};
-#else
     : detail::is_equality_comparable_impl::type<T, U> {};
-#endif
 
 
 // return `!( b < a || a == b)`. synthesized from `U < T` and `T == U`

--- a/include/preview/__utility/cxx20_rel_ops.h
+++ b/include/preview/__utility/cxx20_rel_ops.h
@@ -67,7 +67,14 @@ struct is_equality_comparable_impl {
 
 template<typename T, typename U>
 struct is_equality_comparable
+#if (defined(__GNUC__) || defined(__GNUG__)) && !defined(__clang__) && (__GNUC__ >= 12)
+    : disjunction<
+        detail::equality_comparable_precxx20<T, U>,
+        detail::equality_comparable_precxx20<U, T>
+    > {};
+#else
     : detail::is_equality_comparable_impl::type<T, U> {};
+#endif
 
 
 // return `!( b < a || a == b)`. synthesized from `U < T` and `T == U`

--- a/include/preview/__utility/cxx20_rel_ops.h
+++ b/include/preview/__utility/cxx20_rel_ops.h
@@ -69,8 +69,8 @@ template<typename T, typename U>
 struct is_equality_comparable
 #if (defined(__GNUC__) || defined(__GNUG__)) && !defined(__clang__)
     : disjunction<
-        preview::detail::equality_comparable_precxx20<T, U>,
-        preview::detail::equality_comparable_precxx20<U, T>
+        detail::equality_comparable_precxx20<T, U>,
+        detail::equality_comparable_precxx20<U, T>
     > {};
 #else
     : detail::is_equality_comparable_impl::type<T, U> {};

--- a/include/preview/__utility/cxx20_rel_ops.h
+++ b/include/preview/__utility/cxx20_rel_ops.h
@@ -82,6 +82,7 @@ struct is_equality_comparable
 template<typename T, typename U, std::enable_if_t<conjunction<
     negation<std::is_same<T, U>>,
     is_equality_comparable<T, U>,
+    negation<preview::detail::less_than_comparable_precxx20<const T&, const U&>>,
     preview::detail::less_than_comparable_precxx20<const U&, const T&>
   >::value, int> = 0>
 constexpr bool operator<(const T& a, const U& b) noexcept(noexcept(!( (b < a) || (a == b)))) {

--- a/include/preview/__utility/cxx20_rel_ops.h
+++ b/include/preview/__utility/cxx20_rel_ops.h
@@ -21,17 +21,16 @@ namespace rel_ops {
 namespace detail {
 
 template<typename T, typename U, typename = void>
-struct has_operator_equal_2 : std::false_type {};
+struct equality_comparable_precxx20 : std::false_type {};
+
 template<typename T, typename U>
-struct has_operator_equal_2<
-        T, U,
-        void_t<decltype( std::declval<T>() == std::declval<U>() )>
-    > : std::is_convertible<decltype( std::declval<T>() == std::declval<U>() ), bool> {};
+struct equality_comparable_precxx20<T, U, void_t<decltype( std::declval<T>() == std::declval<U>() )>>
+    : std::is_convertible<decltype( std::declval<T>() == std::declval<U>() ), bool> {};
 
 template<typename T, typename U, typename = void>
-struct has_operator_less_2 : std::false_type {};
+struct less_than_comparable_precxx20 : std::false_type {};
 template<typename T, typename U>
-struct has_operator_less_2<
+struct less_than_comparable_precxx20<
         T, U,
         void_t<decltype( std::declval<T>() < std::declval<U>() )>
     > : std::is_convertible<decltype( std::declval<T>() < std::declval<U>() ), bool> {};
@@ -43,7 +42,7 @@ struct has_operator_less_2<
 // synthesized from `U == T`
 template<typename T, typename U, std::enable_if_t<conjunction<
     negation<std::is_same<T, U>>,
-    detail::has_operator_equal_2<const U&, const T&>
+    detail::equality_comparable_precxx20<const U&, const T&>
 >::value, int> = 0>
 constexpr bool operator==(const T& a, const U& b) noexcept(noexcept(b == a)) {
   return b == a;
@@ -74,8 +73,7 @@ struct is_equality_comparable : detail::is_equality_comparable_impl::type<T, U> 
 template<typename T, typename U, std::enable_if_t<conjunction<
     negation<std::is_same<T, U>>,
     is_equality_comparable<T, U>,
-    negation< detail::has_operator_less_2<const T&, const U&> >,
-    detail::has_operator_less_2<const U&, const T&>
+    detail::less_than_comparable_precxx20<const U&, const T&>
   >::value, int> = 0>
 constexpr bool operator<(const T& a, const U& b) noexcept(noexcept(!( (b < a) || (a == b)))) {
   // (a < b) -> !(a >= b) -> !( a > b || a == b) -> !( b < a || a == b)

--- a/include/preview/__utility/to_unsigned_like.h
+++ b/include/preview/__utility/to_unsigned_like.h
@@ -1,0 +1,20 @@
+//
+// Created by YongGyu Lee on 2024. 6. 28
+//
+
+#ifndef PREVIEW_TYPE_TRAITS_TO_UNSIGNED_LIKE_H_
+#define PREVIEW_TYPE_TRAITS_TO_UNSIGNED_LIKE_H_
+
+#include <type_traits>
+#include "preview/__type_traits/is_integer_like.h"
+
+namespace preview {
+
+template<typename T, std::enable_if_t<is_integer_like<T>::value, int> = 0>
+constexpr auto to_unsigned_like(T x) noexcept {
+  return static_cast<std::make_unsigned_t<T>>(x);
+}
+
+} // namespace preview
+
+#endif // PREVIEW_TYPE_TRAITS_TO_UNSIGNED_LIKE_H_

--- a/include/preview/string_view.h
+++ b/include/preview/string_view.h
@@ -16,7 +16,9 @@
 #include <string>
 #include <ostream>
 
-#if __cplusplus >= 201703L
+#include "preview/core.h"
+
+#if PREVIEW_CXX_VERSION >= 17
 #include <string_view>
 #endif
 
@@ -40,54 +42,14 @@
 #include "preview/__type_traits/remove_cvref.h"
 
 namespace preview {
-
 namespace detail {
-
-template<
-    typename It,
-    typename End,
-    typename CharT,
-    typename SizeType,
-    bool = conjunction<
-               contiguous_iterator<It>,
-               sized_sentinel_for<End, It>,
-               has_typename_type<iter_value<It>>,
-               negation<std::is_convertible<It, SizeType>>
-           >::value /* true */
->
-struct string_view_iter_ctor : std::is_same<iter_value_t<It>, CharT> {};
-
-template<typename It, typename End, typename CharT, typename SizeType>
-struct string_view_iter_ctor<It, End, CharT, SizeType, false> : std::false_type {};
 
 template<typename D, typename SV, typename = void>
 struct has_operator_string_view
-#if __cplusplus < 202002L
-  : std::is_same<D, std::string> {};
-#else
   : std::false_type {};
-#endif
 template<typename D, typename SV>
-struct has_operator_string_view<D, SV, void_t<decltype( std::declval<D&>().operator SV() )>> : std::true_type {};
-
-template<
-    typename R,
-    typename SV,
-    bool = conjunction<
-               negation< std::is_same<remove_cvref_t<R>, SV> >,
-               ranges::contiguous_range<R>,
-               ranges::sized_range<R>,
-               has_typename_type<ranges::range_value<R>>
-           >::value /* true */
->
-struct string_view_range_ctor
-    : conjunction<
-          std::is_same<ranges::range_value_t<R>, typename SV::value_type>,
-          negation< std::is_convertible<R, typename SV::const_pointer> >,
-          negation< has_operator_string_view<remove_cvref_t<R>, SV> >
-      >{};
-template<typename R, typename SV>
-struct string_view_range_ctor<R, SV, false> : std::false_type {};
+struct has_operator_string_view<D, SV, void_t<decltype( std::declval<D&>().operator SV() )>>
+    : std::is_same<SV, decltype( std::declval<D&>().operator SV() )> {};
 
 } // namespace detail
 
@@ -122,12 +84,25 @@ class basic_string_view {
   constexpr basic_string_view( const CharT* s )
       : data_(s), size_(traits_type::length(s)) {}
 
-  template<typename It, typename End, std::enable_if_t<
-      detail::string_view_iter_ctor<It, End, CharT, size_type>::value, int> =0>
+  template<typename It, typename End, std::enable_if_t<conjunction<
+      contiguous_iterator<It>,
+      sized_sentinel_for<End, It>,
+      same_as<iter_value_t<It>, CharT>,
+      negation<convertible_to<End, std::size_t>>
+  >::value, int> =0>
   constexpr basic_string_view(It first, End last)
       : data_(preview::to_address(first)), size_(last - first) {}
 
-  template<typename  R, std::enable_if_t<detail::string_view_range_ctor<R, basic_string_view>::value, int> = 0>
+  template<typename  R, std::enable_if_t<conjunction<
+      negation<same_as<remove_cvref_t<R>, basic_string_view>>,
+      ranges::contiguous_range<R>,
+      ranges::sized_range<R>,
+      negation<convertible_to<R, const CharT*>>,
+      negation<detail::has_operator_string_view<remove_cvref_t<R>, basic_string_view>>
+#if PREVIEW_CXX_VERSION >= 17
+      , negation<detail::has_operator_string_view<remove_cvref_t<R>, std::basic_string_view<CharT, Traits>>>
+#endif
+  >::value, int> = 0>
   constexpr explicit basic_string_view(R&& r)
       : data_(ranges::data(r)), size_(ranges::size(r)) {}
 

--- a/include/preview/string_view.h
+++ b/include/preview/string_view.h
@@ -17,6 +17,7 @@
 #include <ostream>
 
 #include "preview/core.h"
+#include "preview/__type_traits/has_conversion_operator.h"
 
 #if PREVIEW_CXX_VERSION >= 17
 #include <string_view>
@@ -42,16 +43,6 @@
 #include "preview/__type_traits/remove_cvref.h"
 
 namespace preview {
-namespace detail {
-
-template<typename D, typename SV, typename = void>
-struct has_operator_string_view
-  : std::false_type {};
-template<typename D, typename SV>
-struct has_operator_string_view<D, SV, void_t<decltype( std::declval<D&>().operator SV() )>>
-    : std::is_same<SV, decltype( std::declval<D&>().operator SV() )> {};
-
-} // namespace detail
 
 template<
     typename CharT,
@@ -98,9 +89,9 @@ class basic_string_view {
       ranges::contiguous_range<R>,
       ranges::sized_range<R>,
       negation<convertible_to<R, const CharT*>>,
-      negation<detail::has_operator_string_view<remove_cvref_t<R>, basic_string_view>>
+      negation<has_conversion_operator<remove_cvref_t<R>, basic_string_view>>
 #if PREVIEW_CXX_VERSION >= 17
-      , negation<detail::has_operator_string_view<remove_cvref_t<R>, std::basic_string_view<CharT, Traits>>>
+      , negation<has_conversion_operator<remove_cvref_t<R>, std::basic_string_view<CharT, Traits>>>
 #endif
   >::value, int> = 0>
   constexpr explicit basic_string_view(R&& r)

--- a/include/preview/tuple.h
+++ b/include/preview/tuple.h
@@ -9,6 +9,7 @@
 # include "preview/__tuple/make_from_tuple.h"
 # include "preview/__tuple/tuple_fold.h"
 # include "preview/__tuple/tuple_for_each.h"
+# include "preview/__tuple/tuple_integer_sequence.h"
 # include "preview/__tuple/tuple_like.h"
 # include "preview/__tuple/tuple_transform.h"
 

--- a/include/preview/type_traits.h
+++ b/include/preview/type_traits.h
@@ -14,6 +14,7 @@
 #include "preview/__type_traits/copy_cvref.h"
 #include "preview/__type_traits/copy_template.h"
 #include "preview/__type_traits/disjunction.h"
+#include "preview/__type_traits/has_conversion_operator.h"
 #include "preview/__type_traits/has_operator_arrow.h"
 #include "preview/__type_traits/has_typename_difference_type.h"
 #include "preview/__type_traits/has_typename_element_type.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -136,7 +136,9 @@ function(preview_add_multi_version_test name_prefix test_src)
             target_compile_options(${name_prefix}_${std}
                 PRIVATE "-Wall"
                 PRIVATE "-Werror"
-                PRIVATE "-Wno-unused-local-typedef")
+                PRIVATE "-Wno-unused-local-typedef"
+                PRIVATE "-Wno-unused-variable"
+            )
         endif ()
     endforeach ()
 endfunction()

--- a/test/ranges.cc
+++ b/test/ranges.cc
@@ -365,17 +365,13 @@ void mutate(V& v)
 template<class K, class V>
 void mutate_map_values(std::multimap<K, V>& m, K k)
 {
-#if PREVIEW_CXX_VERSION >= 20
+#if PREVIEW_CXX_VERSION >= 17
   auto [first, last] = m.equal_range(k);
   for (auto& [_, v] : ranges::subrange(first, last))
     mutate(v);
-#elif PREVIEW_CXX_VERSION >= 17
-  auto [first, last] = m.equal_range(k);
-  for (auto& [_, v] : ranges::make_subrange(first, last))
-    mutate(v);
 #else
-  auto p =  m.equal_range(k);
-  for (auto& p : ranges::make_subrange(p.first, p.second))
+  auto r =  m.equal_range(k);
+  for (auto& p : ranges::make_subrange(r.first, r.second))
     mutate(p.second);
 #endif
 }

--- a/test/ranges.cc
+++ b/test/ranges.cc
@@ -12,33 +12,36 @@
 #include "preview/span.h"
 #include "preview/string_view.h"
 
+namespace ranges = preview::ranges;
+namespace views = preview::views;
+
 TEST(VERSIONED(Ranges), basics) {
   auto const ints = {0, 1, 2, 3, 4, 5};
   auto even = [](int i) { return 0 == i % 2; };
   auto square = [](int i) { return i * i; };
 
   // the "pipe" syntax of composing the views:
-  for (int i : ints | preview::views::filter(even) | preview::views::transform(square))
+  for (int i : ints | views::filter(even) | views::transform(square))
     std::cout << i << ' ';
 
-  auto cr = ints | preview::views::filter(even) | preview::views::transform(square) | preview::views::common;
+  auto cr = ints | views::filter(even) | views::transform(square) | views::common;
   const auto answer = {0, 4, 16};
   EXPECT_TRUE(std::equal(cr.begin(), cr.end(), answer.begin(), answer.end()));
 
   std::cout << '\n';
 
   // a traditional "functional" composing syntax:
-  for (int i : preview::views::transform(preview::views::filter(ints, even), square))
+  for (int i : views::transform(views::filter(ints, even), square))
     std::cout << i << ' ';
 
-  auto t = preview::views::transform(preview::views::filter(ints, even), square);
+  auto t = views::transform(views::filter(ints, even), square);
   EXPECT_TRUE(std::equal(t.begin(), t.end(), answer.begin(), answer.end()));
 }
 
 TEST(VERSIONED(Ranges), ranges_begin) {
   std::vector<int> v{3, 1, 4};
-  auto vi = preview::ranges::begin(v);
-  auto vci = preview::ranges::cbegin(v);
+  auto vi = ranges::begin(v);
+  auto vci = ranges::cbegin(v);
   EXPECT_EQ(*vi, 3);
   EXPECT_EQ(*vi, *vci);
 
@@ -53,7 +56,7 @@ TEST(VERSIONED(Ranges), ranges_begin) {
   // *vci = 13; // Error: vci points to immutable element
 
   int a[]{-5, 10, 15};
-  auto ai = preview::ranges::begin(a); // works with C-arrays as well
+  auto ai = ranges::begin(a); // works with C-arrays as well
   EXPECT_EQ(*ai, -5);
   *ai = 42; // OK
   EXPECT_EQ(*ai, 42);
@@ -62,22 +65,22 @@ TEST(VERSIONED(Ranges), ranges_begin) {
 
 TEST(VERSIONED(Ranges), ranges_end) {
   std::vector<int> vec{3, 1, 4};
-  EXPECT_TRUE (preview::ranges::find(vec, 5) == preview::ranges::end(vec));
+  EXPECT_TRUE (ranges::find(vec, 5) == ranges::end(vec));
 
   int arr[]{5, 10, 15};
-  EXPECT_TRUE (preview::ranges::find(arr, 5) != preview::ranges::end(arr));
+  EXPECT_TRUE (ranges::find(arr, 5) != ranges::end(arr));
 }
 
 TEST(VERSIONED(Ranges), ranges_cbegin) {
   std::vector<int> v{3, 1, 4};
-  auto vi = preview::ranges::cbegin(v);
+  auto vi = ranges::cbegin(v);
   EXPECT_EQ(3, *vi);
   ++vi; // OK, constant-iterator object is mutable
   EXPECT_EQ(1, *vi);
   EXPECT_FALSE((std::is_assignable<decltype(*vi), int>::value));
 
   int a[]{3, 1, 4};
-  auto ai = preview::ranges::cbegin(a); // cbegin works with C-arrays as well
+  auto ai = ranges::cbegin(a); // cbegin works with C-arrays as well
   EXPECT_EQ(3, *ai);
   EXPECT_EQ(*(ai + 1), 1);
   EXPECT_FALSE((std::is_assignable<decltype(*ai), int>::value));
@@ -88,30 +91,30 @@ TEST(VERSIONED(Ranges), ranges_cend) {
   std::vector<int> vec{3, 1, 4};
   int arr[]{5, 10, 15};
 
-  EXPECT_EQ(preview::ranges::find(vec, 5), preview::ranges::cend(vec));
-  EXPECT_NE(preview::ranges::find(arr, 5), preview::ranges::cend(arr));
+  EXPECT_EQ(ranges::find(vec, 5), ranges::cend(vec));
+  EXPECT_NE(ranges::find(arr, 5), ranges::cend(arr));
 }
 
 TEST(VERSIONED(Ranges), ranges_rbegin) {
   std::vector<int> v = {3, 1, 4};
-  auto vi = preview::ranges::rbegin(v);
+  auto vi = ranges::rbegin(v);
   EXPECT_EQ(*vi, 4);
   *vi = 42; // OK
   EXPECT_EQ(*vi, 42);
   EXPECT_EQ(v.back(), 42);
 
   int a[] = {-5, 10, 15};
-  auto ai = preview::ranges::rbegin(a);
+  auto ai = ranges::rbegin(a);
   EXPECT_EQ(*ai, 15);
   *ai = 42; // OK
   EXPECT_EQ(*ai, 42);
   EXPECT_EQ(a[2], 42);
 
-  EXPECT_FALSE ((preview::is_invocable<decltype(preview::ranges::rbegin), std::vector<int>>::value));
+  EXPECT_FALSE ((preview::is_invocable<decltype(ranges::rbegin), std::vector<int>>::value));
   // ill-formed: the argument is a rvalue
 
-  auto si = preview::ranges::rbegin(preview::span<int, 3>{a}); // OK
-  static_assert(preview::ranges::enable_borrowed_range<
+  auto si = ranges::rbegin(preview::span<int, 3>{a}); // OK
+  static_assert(ranges::enable_borrowed_range<
       std::remove_cv_t<decltype(preview::span<int, 3>{a})>>, "");
   *si = 43; // OK
   EXPECT_EQ(*si, 43);
@@ -129,7 +132,7 @@ TEST(VERSIONED(Ranges), ranges_rend) {
 
 TEST(VERSIONED(Ranges), ranges_crbegin) {
   std::vector<int> v{3, 1, 4};
-  auto vi = preview::ranges::crbegin(v);
+  auto vi = ranges::crbegin(v);
   EXPECT_EQ(*vi, 4);
   ++vi; // OK, iterator object is mutable
   EXPECT_EQ(*vi, 1);
@@ -137,17 +140,17 @@ TEST(VERSIONED(Ranges), ranges_crbegin) {
   // *vi = 13; // Error: underlying element is read-only
 
   int a[]{-5, 10, 15};
-  auto ai = preview::ranges::crbegin(a);
+  auto ai = ranges::crbegin(a);
   EXPECT_EQ(*ai, 15);
 
-  // auto x_x = preview::ranges::crbegin(std::vector<int>{6, 6, 6});
-  // ill-formed: the argument is a rvalue (see Notes ↑)
-  EXPECT_FALSE((preview::is_invocable<decltype(preview::ranges::crbegin), std::vector<int>>::value));
+  // auto x_x = ranges::crbegin(std::vector<int>{6, 6, 6});
+  // ill-formed: the argument is a rvalue
+  EXPECT_FALSE((preview::is_invocable<decltype(ranges::crbegin), std::vector<int>>::value));
 
-  auto si = preview::ranges::crbegin(preview::span<int, 3>{a}); // OK
+  auto si = ranges::crbegin(preview::span<int, 3>{a}); // OK
   EXPECT_EQ(*si, 15);
   static_assert(
-      preview::ranges::enable_borrowed_range<
+      ranges::enable_borrowed_range<
           std::remove_cv_t<decltype(preview::span<int, 3>{a})>
       >,
       "");
@@ -158,7 +161,7 @@ TEST(VERSIONED(Ranges), ranges_crend) {
   const int b[]{10, 9, -3, 6, 4};
 
   namespace ranges = preview::ranges;
-  EXPECT_TRUE(preview::ranges::equal(
+  EXPECT_TRUE(ranges::equal(
       ranges::rbegin(a), ranges::rend(a),
       ranges::begin(b), ranges::end(b)
   ));
@@ -170,20 +173,20 @@ TEST(VERSIONED(Ranges), ranges_crend) {
 
 TEST(VERSIONED(Ranges), ranges_size) {
   auto v = std::vector<int>{};
-  EXPECT_EQ(preview::ranges::size(v), 0);
+  EXPECT_EQ(ranges::size(v), 0);
 
   auto il = {7};     // std::initializer_list
-  EXPECT_EQ(preview::ranges::size(il), 1);
+  EXPECT_EQ(ranges::size(il), 1);
 
   int array[]{4, 5}; // array has a known bound
-  EXPECT_EQ(preview::ranges::size(array), 2);
+  EXPECT_EQ(ranges::size(array), 2);
 
-  EXPECT_FALSE(std::is_signed<decltype(preview::ranges::size(v))>::value);
+  EXPECT_FALSE(std::is_signed<decltype(ranges::size(v))>::value);
 }
 
 TEST(VERSIONED(Ranges), ranges_ssize) {
   std::array<int, 5> arr{1, 2, 3, 4, 5};
-  auto s = preview::ranges::ssize(arr);
+  auto s = ranges::ssize(arr);
   EXPECT_EQ(s, 5);
   EXPECT_TRUE(std::is_signed<decltype(s)>::value);
 
@@ -194,18 +197,18 @@ TEST(VERSIONED(Ranges), ranges_ssize) {
 TEST(VERSIONED(Ranges), ranges_empty) {
   {
     auto v = std::vector<int>{1, 2, 3};
-    EXPECT_FALSE(preview::ranges::empty(v));
+    EXPECT_FALSE(ranges::empty(v));
     v.clear();
-    EXPECT_TRUE (preview::ranges::empty(v));
+    EXPECT_TRUE (ranges::empty(v));
   }
   {
     auto il = {7, 8, 9};
-    EXPECT_FALSE(preview::ranges::empty(il));
-    EXPECT_TRUE (preview::ranges::empty(std::initializer_list<int>{}));
+    EXPECT_FALSE(ranges::empty(il));
+    EXPECT_TRUE (ranges::empty(std::initializer_list<int>{}));
   }
   {
     int array[] = {4, 5, 6}; // array has a known bound
-    EXPECT_FALSE(preview::ranges::empty(array));
+    EXPECT_FALSE(ranges::empty(array));
   }
   {
     struct Scanty : private std::vector<int>
@@ -217,9 +220,9 @@ TEST(VERSIONED(Ranges), ranges_empty) {
     };
 
     Scanty y;
-    EXPECT_TRUE (preview::ranges::empty(y));
+    EXPECT_TRUE (ranges::empty(y));
     y.push_back(42);
-    EXPECT_FALSE(preview::ranges::empty(y));
+    EXPECT_FALSE(ranges::empty(y));
   }
 }
 
@@ -227,8 +230,8 @@ TEST(VERSIONED(Ranges), ranges_data) {
   std::string s{"Hello world!\n"};
 
   char a[20]; // storage for a C-style string
-  preview::ranges::data(s);
-  std::strcpy(a, preview::ranges::data(s));
+  ranges::data(s);
+  std::strcpy(a, ranges::data(s));
   // [data(s), data(s) + size(s)] is guaranteed to be an NTBS
   EXPECT_TRUE((std::strncmp(a, s.c_str(), 20) == 0));
 }
@@ -236,14 +239,14 @@ TEST(VERSIONED(Ranges), ranges_data) {
 TEST(VERSIONED(Ranges), ranges_cdata) {
   std::string src {"hello world!\n"};
 
-//  preview::ranges::cdata(src)[0] = 'H'; // error, src.data() is treated as read-only
-  EXPECT_FALSE((std::is_assignable<decltype(preview::ranges::cdata(src)[0]), int>::value));
+//  ranges::cdata(src)[0] = 'H'; // error, src.data() is treated as read-only
+  EXPECT_FALSE((std::is_assignable<decltype(ranges::cdata(src)[0]), int>::value));
 
-  preview::ranges::data(src)[0] = 'H'; // OK, src.data() is a non-const storage
+  ranges::data(src)[0] = 'H'; // OK, src.data() is a non-const storage
   EXPECT_EQ(src[0], 'H');
 
   char dst[20]; // storage for a C-style string
-  std::strcpy(dst, preview::ranges::cdata(src));
+  std::strcpy(dst, ranges::cdata(src));
   EXPECT_TRUE((std::strncmp(dst, src.c_str(), 20) == 0));
   // [data(src), data(src) + size(src)] is guaranteed to be an NTBS
 }
@@ -252,42 +255,188 @@ TEST(VERSIONED(Ranges), ranges_dangling) {
   auto get_array_by_value = [] {
     return std::array<int, 4>{0, 1, 0, 1};
   };
-  auto dangling_iter = preview::ranges::max_element(get_array_by_value());
-  static_assert(std::is_same<preview::ranges::dangling, decltype(dangling_iter)>::value, "");
+  auto dangling_iter = ranges::max_element(get_array_by_value());
+  static_assert(std::is_same<ranges::dangling, decltype(dangling_iter)>::value, "");
   static_assert(preview::dereferenceable<decltype(dangling_iter)>::value == false, "");
   //  *dangling_iter << '\n'; // compilation error: no match for 'operator*'
-  //  (operand type is 'std::ranges::dangling')
+  //  (operand type is 'ranges::dangling')
 
   auto get_persistent_array = []() -> const std::array<int, 4>& {
     static constexpr std::array<int, 4> a{0, 1, 0, 1};
     return a;
   };
-  auto valid_iter = preview::ranges::max_element(get_persistent_array());
-  static_assert(!std::is_same<preview::ranges::dangling, decltype(valid_iter)>::value, "");
+  auto valid_iter = ranges::max_element(get_persistent_array());
+  static_assert(!std::is_same<ranges::dangling, decltype(valid_iter)>::value, "");
   EXPECT_EQ(*valid_iter, 1);
 
   auto get_string_view = [] { return preview::string_view{"alpha"}; };
-  auto valid_iter2 = preview::ranges::min_element(get_string_view());
+  auto valid_iter2 = ranges::min_element(get_string_view());
   // OK: std::basic_string_view models borrowed_range
-  static_assert(!std::is_same<preview::ranges::dangling, decltype(valid_iter2)>::value, "");
+  static_assert(!std::is_same<ranges::dangling, decltype(valid_iter2)>::value, "");
   EXPECT_EQ(*valid_iter2, 'a');
 }
 
 TEST(VERSIONED(Ranges), to) {
-  auto map = preview::views::iota('A', 'E') |
-      preview::views::enumerate |
-      preview::ranges::to<std::map>();
+  auto map = views::iota('A', 'E') |
+      views::enumerate |
+      ranges::to<std::map>();
 
   std::cout << map[0] << std::endl;
   std::cout << map[1] << std::endl;
   std::cout << map[2] << std::endl;
 }
 
+template<class T, class A>
+class VectorView : public ranges::view_interface<VectorView<T, A>>
+{
+ public:
+  VectorView() = default;
+
+  VectorView(const std::vector<T, A>& vec) :
+      m_begin(vec.cbegin()), m_end(vec.cend())
+  {}
+
+  auto begin() const { return m_begin; }
+
+  auto end() const { return m_end; }
+
+ private:
+  typename std::vector<T, A>::const_iterator m_begin{}, m_end{};
+};
+
+TEST(VERSIONED(Ranges), view_interface) {
+  { // empty
+    constexpr std::array<int, 5> a{0, 1, 2, 3, 4};
+#if PREVIEW_CXX_VERSION >= 17
+    static_assert(!ranges::single_view(a).empty());
+#else
+    static_assert(!ranges::single_view<std::array<int, 5>>(a).empty(), "");
+#endif
+    EXPECT_TRUE((a | views::take(0)).empty());
+    EXPECT_FALSE((a | views::take(5)).empty());
+    EXPECT_TRUE((a | views::drop(5)).empty());
+    EXPECT_FALSE((a | views::drop(3)).empty());
+    static_assert(views::iota(0, 0).empty(), "");
+    static_assert(!views::iota(0).empty(), "");
+  }
+
+  { // operator bool
+
+    const std::array<int, 5> ints {0, 1, 2, 3, 4};
+    auto odds = ints | views::filter([](int i) { return 0 != i % 2; });
+    auto negs = ints | views::filter([](int i) { return i < 0; });
+    EXPECT_TRUE(!!odds); // Has odd numbers
+    EXPECT_FALSE(!!negs); // Doesn't have negative numbers
+  }
+
+  { // data
+    PREVIEW_CONSTEXPR_AFTER_CXX17 preview::string_view str { "Hello, C++20!" };
+    std::cout << (str | views::drop(7)).data() << '\n';
+    constexpr static std::array<int, 5> a { 1,2,3,4,5 };
+    PREVIEW_CONSTEXPR_AFTER_CXX17 auto v { a | views::take(3) };
+#if PREVIEW_CXX_VERSION >= 17
+    static_assert( &a[0] == v.data());
+#else
+    EXPECT_EQ(&a[0], v.data());
+#endif
+  }
+
+  std::vector<int> v = {1, 4, 9, 16};
+
+  VectorView<int, typename std::vector<int>::allocator_type> view_over_v{v};
+
+  // We can iterate with begin() and end().
+  for (int n : view_over_v)
+    std::cout << n << ' ';
+  std::cout << '\n';
+
+  // We get operator[] for free when inheriting from view_interface
+  // since we satisfy the random_access_range concept.
+  for (std::ptrdiff_t i = 0; i != view_over_v.size(); ++i)
+    std::cout << "v[" << i << "] = " << view_over_v[i] << '\n';
+}
+
+template<class V>
+void mutate(V& v)
+{
+  v += 'A' - 'a';
+}
+
+template<class K, class V>
+void mutate_map_values(std::multimap<K, V>& m, K k)
+{
+#if PREVIEW_CXX_VERSION >= 20
+  auto [first, last] = m.equal_range(k);
+  for (auto& [_, v] : ranges::subrange(first, last))
+    mutate(v);
+#elif PREVIEW_CXX_VERSION >= 17
+  auto [first, last] = m.equal_range(k);
+  for (auto& [_, v] : ranges::make_subrange(first, last))
+    mutate(v);
+#else
+  auto p =  m.equal_range(k);
+  for (auto& p : ranges::make_subrange(p.first, p.second))
+    mutate(p.second);
+#endif
+}
+
+TEST(VERSIONED(Ranges), subrange) {
+  std::multimap<int, char> mm{{4, 'a'}, {3, '-'}, {4, 'b'}, {5, '-'}, {4, 'c'}};
+  mutate_map_values(mm, 4);
+
+  auto it = mm.begin();
+  EXPECT_EQ(it->second, '-'); ++it;
+  EXPECT_EQ(it->second, 'A'); ++it;
+  EXPECT_EQ(it->second, 'B'); ++it;
+  EXPECT_EQ(it->second, 'C'); ++it;
+  EXPECT_EQ(it->second, '-'); ++it;
+}
+
+// Define Slice as a range adaptor closure
+struct Slice : ranges::range_adaptor_closure<Slice> {
+  std::size_t start = 0;
+  std::size_t end = preview::string_view::npos;
+
+  constexpr preview::string_view operator()(preview::string_view sv) const
+  {
+    return sv.substr(start, end - start);
+  }
+};
+TEST(VERSIONED(Ranges), range_adaptor_closure) {
+
+  const preview::string_view str = "01234567";
+
+#if PREVIEW_CXX_VERSION >= 20
+  Slice slicer{.start = 1, .end = 6};
+#else
+  Slice slicer{};
+  slicer.start = 1;
+  slicer.end = 6;
+#endif
+
+  auto sv1 = slicer(str); // use slicer as a normal function object
+  auto sv2 = str | slicer; // use slicer as a range adaptor closure object
+  EXPECT_EQ(sv1, "12345");
+  EXPECT_EQ(sv2, "12345");
+
+  // range adaptor closures can be composed
+  auto slice_and_drop
+      = slicer
+          | views::drop_while([](char ch) { return ch != '3'; });
+  for (auto&& c : str | slice_and_drop) {
+     std::cout << c;
+  }
+
+  auto sv = (str | slice_and_drop).operator preview::string_view();
+  preview::string_view(str | slice_and_drop);
+  // EXPECT_TRUE((preview::string_view(str | slice_and_drop) == "345"));
+}
+
 
 TEST(VERSIONED(Ranges), iterator_conforming) {
-  auto r = preview::views::iota(0) |
-      preview::views::take(10) |
-      preview::views::filter([](auto x) { return x % 2 == 0; });
+  auto r = views::iota(0) |
+      views::take(10) |
+      views::filter([](auto x) { return x % 2 == 0; });
 
   static_assert(std::is_same<
       std::iterator_traits<decltype(r.begin())>::reference,
@@ -299,7 +448,7 @@ TEST(VERSIONED(Ranges), iterator_conforming) {
   preview::string_view sv = "world";
   std::list<char> l = {'!'};
 
-  for (auto c : preview::views::concat(v, s, sv, l)) {
+  for (auto c : views::concat(v, s, sv, l)) {
     std::cout << c;
   }
 }

--- a/test/ranges.cc
+++ b/test/ranges.cc
@@ -427,9 +427,7 @@ TEST(VERSIONED(Ranges), range_adaptor_closure) {
      std::cout << c;
   }
 
-  auto sv = (str | slice_and_drop).operator preview::string_view();
-  preview::string_view(str | slice_and_drop);
-  // EXPECT_TRUE((preview::string_view(str | slice_and_drop) == "345"));
+  EXPECT_TRUE((preview::string_view(str | slice_and_drop) == "345"));
 }
 
 

--- a/test/ranges.cc
+++ b/test/ranges.cc
@@ -423,6 +423,11 @@ TEST(VERSIONED(Ranges), range_adaptor_closure) {
   auto slice_and_drop
       = slicer
           | views::drop_while([](char ch) { return ch != '3'; });
+  static_assert(ranges::is_range_adaptor_closure<Slice>::value, "");
+
+  auto filter = views::drop_while([](char ch) { return ch != '3'; });
+  static_assert(ranges::is_range_adaptor_closure<preview::remove_cvref_t<decltype(filter)>>::value, "");
+
   for (auto&& c : str | slice_and_drop) {
      std::cout << c;
   }

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -528,8 +528,10 @@ TEST(VERSIONED(RangesViews), take_while_view) {
   using namespace std::literals;
   using namespace preview::literals;
 
+#if PREVIEW_CXX_VERSION >= 17
   for (int year : views::iota(2020)
       | views::take_while([](int y){ return y < 2026; })) { (void)year; }
+#endif
 
   auto r1 = views::iota(10) | views::take_while([](int x) { return true; });
   auto r2 = views::iota(10, 20) | views::take_while([](int x) { return true; });
@@ -543,9 +545,15 @@ TEST(VERSIONED(RangesViews), take_while_view) {
   ));
 
   const char note[]{"Today is yesterday's tomorrow!..."};
+#if PREVIEW_CXX_VERSION >= 17
   for (char x : ranges::take_while_view(note, [](char c){ return c != '.'; })) { (void)x; }
+#endif
   EXPECT_TRUE(ranges::equal(
+#if PREVIEW_CXX_VERSION >= 17
       ranges::take_while_view(note, [](char c){ return c != '.'; }),
+#else
+      views::take_while(note, [](char c){ return c != '.'; }),
+#endif
       "Today is yesterday's tomorrow!"_sv
   ));
 }

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -324,3 +324,18 @@ TEST(VERSIONED(RangesViews), owning_view) {
   EXPECT_EQ(ov2.size(), 6);
   EXPECT_EQ(ov.size(), 0);
 }
+
+
+TEST(VERSIONED(RangesViews), filter_view) {
+  auto even = [](int i) { return 0 == i % 2; };
+  auto square = [](int i) { return i * i; };
+
+  for (int i : views::iota(0, 6)
+      | views::filter(even)
+      | views::transform(square)) { (void)i; }
+
+  EXPECT_TRUE(ranges::equal(
+      views::iota(0, 6) | views::filter(even) | views::transform(square),
+      {0, 4, 16}
+  ));
+}

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -597,16 +597,13 @@ TEST(VERSIONED(RangesViews), drop_view) {
 
     for (auto it = site.begin(); it != site.end(); ++it)
       std::cout << *it; //                ^^^
-
-    EXPECT_TRUE(ranges::equal(
-#if PREVIEW_CXX_VERSION >= 17
-        ranges::subrange{site.begin(), site.end()},
-#else
-        ranges::make_subrange(site.begin(), site.end()),
-#endif
-        "cppreference.com"
-    ));
     std::cout << '\n';
+
+#if PREVIEW_CXX_VERSION >= 17
+    EXPECT_TRUE(ranges::equal(ranges::subrange{site.begin(), site.end()}, "cppreference.com"));
+#else
+    EXPECT_TRUE(ranges::equal(ranges::make_subrange(site.begin(), site.end()), "cppreference.com"));
+#endif
   }
 
   { // size

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -728,7 +728,7 @@ TEST(VERSIONED(RangesViews), join_view) {
   using namespace std::literals;
   using namespace preview::literals;
 
-  const auto bits = {"https:"sv, "//"sv, "cppreference"sv, "."sv, "com"sv};
+  const auto bits = {"https:"_sv, "//"_sv, "cppreference"_sv, "."_sv, "com"_sv};
   for (char const c : bits | views::join)
     std::cout << c;
   std::cout << '\n';

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -723,3 +723,40 @@ TEST(VERSIONED(RangesViews), drop_while_view) {
       {3, 4, 5}
   ));
 }
+
+TEST(VERSIONED(RangesViews), join_view) {
+  using namespace std::literals;
+  using namespace preview::literals;
+
+  const auto bits = {"https:"sv, "//"sv, "cppreference"sv, "."sv, "com"sv};
+  for (char const c : bits | views::join)
+    std::cout << c;
+  std::cout << '\n';
+  EXPECT_TRUE(ranges::equal(bits | views::join, "https://cppreference.com"_sv));
+
+  const std::vector<std::vector<int>> v{{1, 2}, {3, 4, 5}, {6}, {7, 8, 9}};
+#if PREVIEW_CXX_VERSION >= 17
+  auto jv = ranges::join_view(v);
+#else
+  auto jv = views::join(v);
+#endif
+  for (int const e : jv)
+    std::cout << e << ' ';
+  std::cout << '\n';
+  EXPECT_TRUE(ranges::equal(jv, views::iota(1, 10)));
+
+  std::vector<std::string> ss{"hello", " ", "world", "!"};
+  for (char ch : ss | views::join)
+    std::cout << ch;
+  EXPECT_TRUE(ranges::equal(
+      ss | views::join,
+      "hello world!"s
+  ));
+}
+
+struct Person { int age; std::string name; };
+TEST(VERSIONED(RangesViews), join_view_P2328R1) {
+  std::vector<Person> v;
+  (void)(v | views::transform([](auto& p) -> std::string& { return p.name; })
+           | views::join); // OK
+}

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -153,9 +153,8 @@ TEST(VERSIONED(RangesViews), cartesian_product_view) {
 
   {
 #if PREVIEW_CXX_VERSION >= 17
-    constexpr auto a = std::array{"Curiously"_sv, "Recurring"_sv, "Template"_sv, "Pattern"_sv};
-    constexpr auto v = ranges::cartesian_product_view(a[0], a[1], a[2], a[3]);
-
+    static constexpr auto a = std::array{"Curiously"_sv, "Recurring"_sv, "Template"_sv, "Pattern"_sv};
+    static constexpr auto v = ranges::cartesian_product_view(a[0], a[1], a[2], a[3]);
 #else
     constexpr auto a = std::array<preview::string_view, 4>{"Curiously"_sv, "Recurring"_sv, "Template"_sv, "Pattern"_sv};
     constexpr auto v = ranges::cartesian_product_view<

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -673,6 +673,41 @@ TEST(VERSIONED(RangesViews), drop_while_view) {
   using namespace std::literals;
   using namespace preview::literals;
 
+  { // ctor
+    constexpr std::array<int, 8> data{0, -1, -2, 3, 1, 4, 1, 5};
+
+#if PREVIEW_CXX_VERSION >= 17
+    auto view = ranges::drop_while_view{data, [](int x) { return x <= 0; }};
+#else
+    auto view = views::drop_while(data, [](int x) { return x <= 0; });
+#endif
+
+    for (int x : view)
+      std::cout << x << ' ';
+    std::cout << '\n';
+    EXPECT_TRUE(ranges::equal(view, {3, 1, 4, 1, 5}));
+    EXPECT_TRUE(ranges::equal(data, views::concat(views::repeat(true, 3), views::repeat(false, 5)), {}, view.pred()));
+    EXPECT_EQ(*view.begin(), 3);
+
+    for (auto it = view.begin(); it != view.end(); ++it)
+      std::cout << *it << ' ';
+    std::cout << '\n';
+  }
+
+  { // base
+    std::array<int, 5> data{1, 2, 3, 4, 5};
+    auto func = [](int x) { return x < 3; };
+#if PREVIEW_CXX_VERSION >= 17
+    auto view = ranges::drop_while_view{data, func};
+#else
+    auto view = views::drop_while(data, func);
+#endif
+    EXPECT_TRUE(ranges::equal(view, {3, 4, 5}));
+
+    auto base = view.base(); // `base` refers to the `data`
+    (void)base;
+  }
+
   EXPECT_EQ(trim_left(" \n C++23"), "C++23"_sv);
   preview::string_view src = " \f\n\t\r\vHello, C++20!\f\n\t\r\v ";
 

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -548,12 +548,16 @@ TEST(VERSIONED(RangesViews), take_while_view) {
 #if PREVIEW_CXX_VERSION >= 17
   for (char x : ranges::take_while_view(note, [](char c){ return c != '.'; })) { (void)x; }
 #endif
-  EXPECT_TRUE(ranges::equal(
+
 #if PREVIEW_CXX_VERSION >= 17
+  EXPECT_TRUE(ranges::equal(
       ranges::take_while_view(note, [](char c){ return c != '.'; }),
-#else
-      views::take_while(note, [](char c){ return c != '.'; }),
-#endif
       "Today is yesterday's tomorrow!"_sv
   ));
+#else
+  EXPECT_TRUE(ranges::equal(
+      views::take_while(note, [](char c){ return c != '.'; }),
+      "Today is yesterday's tomorrow!"_sv
+  ));
+#endif
 }

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -405,10 +405,12 @@ TEST(VERSIONED(RangesViews), transform_view) {
   ranges::for_each(in | views::transform(rot13), show);
   EXPECT_TRUE(ranges::equal(in | views::transform(rot13), "pccersrerapr.pbz\n"s));
 
+#if !PREVIEW_ANDROID || defined(PREVIEW_NDK_VERSION_MAJOR) && PREVIEW_NDK_VERSION_MAJOR >= 26
   std::string out;
   ranges::copy(views::transform(in, rot13), std::back_inserter(out));
   EXPECT_EQ(out, "pccersrerapr.pbz\n"s);
   ranges::for_each(out, show);
   ranges::for_each(out | views::transform(rot13), show);
   EXPECT_TRUE(ranges::equal(out | views::transform(rot13), "cppreference.com\n"s));
+#endif
 }

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -1,0 +1,264 @@
+#include "preview/ranges.h"
+#include "gtest.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <deque>
+#include <forward_list>
+#include <iterator>
+#include <list>
+#include <map>
+#include <queue>
+#include <set>
+#include <istream>
+#include <iostream>
+#include <sstream>
+#include <stack>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <valarray>
+#include <vector>
+
+#include "preview/algorithm.h"
+#include "preview/concepts.h"
+#include "preview/span.h"
+#include "preview/string_view.h"
+
+namespace ranges = preview::ranges;
+namespace views = preview::views;
+
+TEST(VERSIONED(RangesViews), empty_view) {
+  ranges::empty_view<long> e;
+  EXPECT_TRUE(ranges::empty(e)); // uses operator bool
+  EXPECT_EQ(0, e.size());
+  EXPECT_EQ(nullptr, e.data());
+  EXPECT_EQ(nullptr, e.begin());
+  EXPECT_EQ(nullptr, e.end());
+  EXPECT_EQ(nullptr, e.cbegin());
+  EXPECT_EQ(nullptr, e.cend());
+}
+
+TEST(VERSIONED(RangesViews), single_view) {
+#if PREVIEW_CXX_VERSION >= 17
+  constexpr ranges::single_view sv1{3.1415}; // uses (const T&) constructor
+#else
+  constexpr ranges::single_view<double> sv1{3.1415}; // uses (const T&) constructor
+#endif
+  EXPECT_TRUE(sv1);
+  EXPECT_FALSE(sv1.empty());
+
+  EXPECT_EQ(*sv1.data(), 3.1415);
+  EXPECT_EQ(*sv1.begin(), 3.1415);
+  EXPECT_EQ(sv1.size(), 1);
+  EXPECT_EQ(std::distance(sv1.begin(), sv1.end()), 1);
+
+  std::string str{"C++20"};
+#if PREVIEW_CXX_VERSION >= 17
+  ranges::single_view sv2{std::move(str)}; // uses (T&&) constructor
+#else
+  ranges::single_view<std::string> sv2{std::move(str)}; // uses (T&&) constructor
+#endif
+  EXPECT_EQ(*sv2.data(), "C++20");
+  EXPECT_EQ(str, "");
+
+  ranges::single_view<std::tuple<int, double, std::string>>
+      sv3{preview::in_place, 42, 3.14, "Hello"}; // uses (std::in_place_t, Args&&... args)
+
+  EXPECT_EQ(std::get<0>(sv3[0]), 42);
+  EXPECT_EQ(std::get<1>(sv3[0]), 3.14);
+  EXPECT_EQ(std::get<2>(sv3[0]), "Hello");
+}
+
+TEST(VERSIONED(RangesViews), iota_view) {
+  struct Bound {
+    int bound;
+    bool operator==(int x) const { return x == bound; }
+  };
+  int answer[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+#if PREVIEW_CXX_VERSION >= 17
+  EXPECT_TRUE(ranges::equal(ranges::iota_view{1, 10}, answer));
+  for (int i : ranges::iota_view{1, 10}) { (void)i; }
+#else
+  EXPECT_TRUE(ranges::equal(ranges::iota_view<int, int>{1, 10}, answer));
+  for (int i : ranges::iota_view<int, int>{1, 10}) { (void)i; }
+#endif
+
+  EXPECT_TRUE(ranges::equal(views::iota(1, 10), answer));
+  for (int i : views::iota(1, 10)) { (void)i; }
+
+  EXPECT_TRUE(ranges::equal(views::iota(1, Bound{10}), answer));
+#if PREVIEW_CXX_VERSION >= 17
+  for (int i : views::iota(1, Bound{10})) { (void)i; }
+#endif
+
+  EXPECT_TRUE(ranges::equal(views::iota(1) | views::take(9), answer));
+#if PREVIEW_CXX_VERSION >= 17
+  for (int i : views::iota(1) | views::take(9)) { (void)i; }
+#endif
+
+  int count = 0;
+  ranges::for_each(views::iota(1, 10), [&](int i) {
+    ++count;
+    (void)i;
+  });
+  EXPECT_EQ(count, 9);
+}
+
+TEST(VERSIONED(RangesViews), basic_istream_view) {
+  auto words = std::istringstream{"today is yesterday's tomorrow"};
+#if PREVIEW_CXX_VERSION >= 17
+  int counter = 0;
+  for (const auto& s : views::istream<std::string>(words)) {
+    if (counter == 0) EXPECT_EQ(s, "today");
+    else if (counter == 1) EXPECT_EQ(s, "is");
+    else if (counter == 2) EXPECT_EQ(s, "yesterday's");
+    else if (counter == 3) EXPECT_EQ(s, "tomorrow");
+    counter++;
+  }
+#endif
+
+  auto floats = std::istringstream{"1.1  2.2\t3.3\v4.4\f55\n66\r7.7  8.8"};
+  std::ostringstream oss;
+  ranges::copy(
+      views::istream<float>(floats),
+      std::ostream_iterator<float>{oss, ", "}
+  );
+
+  EXPECT_EQ(oss.str(), "1.1, 2.2, 3.3, 4.4, 55, 66, 7.7, 8.8, ");
+}
+
+TEST(VERSIONED(RangesViews), repeat_view) {
+  using namespace preview::literals;
+
+  // bounded overload
+  for (auto s : views::repeat("C++"_sv, 3)) { (void)s; }
+  EXPECT_TRUE(ranges::equal(
+      views::repeat("C++"_sv, 3),
+      {"C++"_sv, "C++"_sv, "C++"_sv}
+  ));
+
+  // unbounded overload
+  for (auto s : views::repeat("I know that you know that"_sv) | views::take(3)) { (void)s; }
+  EXPECT_TRUE(ranges::equal(
+      views::repeat("I know that you know that"_sv) | views::take(3),
+      {"I know that you know that"_sv, "I know that you know that"_sv, "I know that you know that"_sv}
+  ));
+}
+
+TEST(VERSIONED(RangesViews), cartesian_product_view) {
+  using namespace preview::literals;
+
+  {
+#if PREVIEW_CXX_VERSION >= 17
+    constexpr auto a = std::array{"Curiously"_sv, "Recurring"_sv, "Template"_sv, "Pattern"_sv};
+    constexpr auto v = ranges::cartesian_product_view(a[0], a[1], a[2], a[3]);
+
+#else
+    constexpr auto a = std::array<preview::string_view, 4>{"Curiously"_sv, "Recurring"_sv, "Template"_sv, "Pattern"_sv};
+    constexpr auto v = ranges::cartesian_product_view<
+        views::all_t<decltype(a[0])>,
+        views::all_t<decltype(a[1])>,
+        views::all_t<decltype(a[2])>,
+        views::all_t<decltype(a[3])>
+    >(a[0], a[1], a[2], a[3]);
+
+#endif
+
+    std::tuple<char const&, char const&, char const&, char const&> first{*v.begin()};
+    EXPECT_EQ(std::get<0>(first), 'C');
+    EXPECT_EQ(std::get<1>(first), 'R');
+    EXPECT_EQ(std::get<2>(first), 'T');
+    EXPECT_EQ(std::get<3>(first), 'P');
+
+    std::tuple<char const&, char const&, char const&, char const&> last{*(v.end() - 1)};
+    EXPECT_EQ(std::get<0>(last), 'y');
+    EXPECT_EQ(std::get<1>(last), 'g');
+    EXPECT_EQ(std::get<2>(last), 'e');
+    EXPECT_EQ(std::get<3>(last), 'n');
+  }
+
+  {
+    constexpr static auto w = {1};
+    constexpr static auto x = {2, 3};
+    constexpr static auto y = {4, 5, 6};
+    constexpr static auto z = {7, 8, 9, 10, 11, 12, 13};
+
+#if PREVIEW_CXX_VERSION >= 17
+    constexpr auto v = ranges::cartesian_product_view(w, x, y, z);
+    static_assert(v.size() == w.size() * x.size() * y.size() * z.size(), "");
+#else
+    auto v = ranges::cartesian_product_view<
+        views::all_t<decltype(w)&>,
+        views::all_t<decltype(x)&>,
+        views::all_t<decltype(y)&>,
+        views::all_t<decltype(z)&>
+    >(w, x, y, z);
+#endif
+    EXPECT_EQ(v.size(), w.size() * x.size() * y.size() * z.size());
+    EXPECT_EQ(v.size(), 42);
+  }
+
+  {
+    const auto x = std::array<char, 2>{'A', 'B'};
+    const auto y = std::vector<int> {1, 2, 3};
+    const auto z = std::list<std::string>{"x", "y", "z", "w"};
+
+    auto print = [](std::tuple<char const &, int const &, std::string const &>) {};
+
+    for (auto const &tuple : views::cartesian_product(x, y, z)) {
+      print(tuple);
+    }
+
+    auto t = [](auto a, auto b, auto c) -> std::tuple<char, int, std::string> {
+      return std::make_tuple(a, b, c);
+    };
+
+    EXPECT_TRUE(ranges::equal(
+        views::cartesian_product(x, y, z),
+        {
+            t('A', 1, "x"), t('A', 1, "y"), t('A', 1, "z"), t('A', 1, "w"),
+            t('A', 2, "x"), t('A', 2, "y"), t('A', 2, "z"), t('A', 2, "w"),
+            t('A', 3, "x"), t('A', 3, "y"), t('A', 3, "z"), t('A', 3, "w"),
+            t('B', 1, "x"), t('B', 1, "y"), t('B', 1, "z"), t('B', 1, "w"),
+            t('B', 2, "x"), t('B', 2, "y"), t('B', 2, "z"), t('B', 2, "w"),
+            t('B', 3, "x"), t('B', 3, "y"), t('B', 3, "z"), t('B', 3, "w"),
+        }
+    ));
+  }
+}
+
+
+TEST(VERSIONED(RangesViews), all_view) {
+  std::vector<int> v{0, 1, 2, 3, 4, 5};
+  for (int n : views::all(v) | views::take(2))
+    std::cout << n << ' ';
+  std::cout << '\n';
+
+  static_assert(std::is_same<
+      decltype(views::single(42)),
+      ranges::single_view<int>
+  >{}, "");
+
+  static_assert(std::is_same<
+      decltype(views::all(v)),
+      ranges::ref_view<std::vector<int, std::allocator<int>>>
+  >{}, "");
+
+  int a[]{1, 2, 3, 4};
+  static_assert(std::is_same<
+      decltype(views::all(a)),
+      ranges::ref_view<int[4]>
+  >{}, "");
+
+  static_assert(std::is_same<
+#if PREVIEW_CXX_VERSION >= 17
+      decltype(ranges::subrange{std::begin(a) + 1, std::end(a) - 1}),
+#else
+      decltype(ranges::make_subrange(std::begin(a) + 1, std::end(a) - 1)),
+#endif
+      ranges::subrange<int*, int*, ranges::subrange_kind(1)>
+  >{}, "");
+}

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -523,3 +523,29 @@ TEST(VERSIONED(RangesViews), take_view) {
 #endif
   EXPECT_EQ(out, "3.141592");
 }
+
+TEST(VERSIONED(RangesViews), take_while_view) {
+  using namespace std::literals;
+  using namespace preview::literals;
+
+  for (int year : views::iota(2020)
+      | views::take_while([](int y){ return y < 2026; })) { (void)year; }
+
+  auto r1 = views::iota(10) | views::take_while([](int x) { return true; });
+  auto r2 = views::iota(10, 20) | views::take_while([](int x) { return true; });
+
+  auto it1 = r1.end();
+  auto it2 = r2.end();
+
+  EXPECT_TRUE(ranges::equal(
+      views::iota(2020) | views::take_while([](int y){ return y < 2026; }),
+      {2020, 2021, 2022, 2023, 2024, 2025}
+  ));
+
+  const char note[]{"Today is yesterday's tomorrow!..."};
+  for (char x : ranges::take_while_view(note, [](char c){ return c != '.'; })) { (void)x; }
+  EXPECT_TRUE(ranges::equal(
+      ranges::take_while_view(note, [](char c){ return c != '.'; }),
+      "Today is yesterday's tomorrow!"_sv
+  ));
+}

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -572,7 +572,10 @@ TEST(VERSIONED(RangesViews), drop_view) {
     ranges::for_each(hi, [](const char c){ std::cout << c; });
     EXPECT_TRUE(ranges::equal(hi, "Hello, C++20"_sv));
 
-    PREVIEW_CONSTEXPR_AFTER_CXX20 auto n = std::distance(hi.cbegin(), ranges::find(hi, 'C'));
+#if PREVIEW_CXX_VERSION >= 20 && (!defined(PREVIEW_NDK_VERSION_MAJOR) || PREVIEW_NDK_VERSION_MAJOR >= 26)
+    constexpr
+#endif
+    auto n = std::distance(hi.cbegin(), ranges::find(hi, 'C'));
 
 #if PREVIEW_CXX_VERSION >= 17
     auto cxx = ranges::drop_view{hi, n};

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -358,16 +358,44 @@ char rot13(const char x) {
 TEST(VERSIONED(RangesViews), transform_view) {
   using namespace std::literals;
   { // ctor
-    std::cout << std::setprecision(15) << std::fixed;
     auto atan1term = ranges::views::transform(
         [](int n) { return ((n % 2) ? -1 : 1) * 1.0 / (2 * n + 1); }
     );
+
+    std::vector<double> out;
     for (const int iterations : {1, 2, 3, 4, 5, 10, 100, 1000, 1'000'000})
     {
       auto seq = views::iota(0, iterations) | atan1term;
       const double accum = std::accumulate(seq.begin(), seq.end(), 0.0);
-      std::cout << "π ~ " << 4 * accum << " (iterations: " << iterations << ")\n";
+      out.push_back(4 * accum);
     }
+    EXPECT_DOUBLE_EQ(out[0], 4.000000000000000);
+    EXPECT_DOUBLE_EQ(out[1], 2.666666666666667);
+    EXPECT_DOUBLE_EQ(out[2], 3.466666666666667);
+    EXPECT_DOUBLE_EQ(out[3], 2.895238095238096);
+    EXPECT_DOUBLE_EQ(out[4], 3.339682539682540);
+    EXPECT_DOUBLE_EQ(out[5], 3.041839618929403);
+    EXPECT_DOUBLE_EQ(out[6], 3.131592903558554);
+    EXPECT_DOUBLE_EQ(out[7], 3.140592653839794);
+    EXPECT_DOUBLE_EQ(out[8], 3.141591653589774);
+  }
+
+  {
+    std::string s{"The length of this string is 42 characters"};
+#if PREVIEW_CXX_VERSION >= 17
+    auto tv = ranges::transform_view{s, [](char c) -> char {
+      return std::toupper(c);
+    }};
+#else
+    auto tv = views::transform(s, [](char c) -> char {
+      return std::toupper(c);
+    });
+#endif
+    std::vector<char> out;
+    for (auto x : tv) { out.push_back(x); }
+
+    EXPECT_TRUE(ranges::equal(out, "THE LENGTH OF THIS STRING IS 42 CHARACTERS"s));
+    EXPECT_EQ(tv.size(), 42);
   }
 
   auto show = [](const unsigned char) {};

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -120,16 +120,16 @@ TEST(VERSIONED(RangesViews), basic_istream_view) {
   }
 #endif
 
-#if !PREVIEW_ANDROID || (PREVIEW_CXX_VERSION < 17 || PREVIEW_NDK_VERSION_MAJOR >= 26)
-  auto floats = std::istringstream{"1.1  2.2\t3.3\v4.4\f55\n66\r7.7  8.8"};
-  std::ostringstream oss;
-  ranges::copy(
-      views::istream<float>(floats),
-      std::ostream_iterator<float>{oss, ", "}
-  );
-
-  EXPECT_EQ(oss.str(), "1.1, 2.2, 3.3, 4.4, 55, 66, 7.7, 8.8, ");
-#endif
+//#if !PREVIEW_ANDROID || (PREVIEW_CXX_VERSION < 17 || PREVIEW_NDK_VERSION_MAJOR >= 26)
+//  auto floats = std::istringstream{"1.1  2.2\t3.3\v4.4\f55\n66\r7.7  8.8"};
+//  std::ostringstream oss;
+//  ranges::copy(
+//      views::istream<float>(floats),
+//      std::ostream_iterator<float>{oss, ", "}
+//  );
+//
+//  EXPECT_EQ(oss.str(), "1.1, 2.2, 3.3, 4.4, 55, 66, 7.7, 8.8, ");
+//#endif
 }
 
 TEST(VERSIONED(RangesViews), repeat_view) {

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -263,3 +263,29 @@ TEST(VERSIONED(RangesViews), all_view) {
       ranges::subrange<int*, int*, ranges::subrange_kind(1)>
   >{}, "");
 }
+
+
+TEST(VERSIONED(RangesViews), ref_view) {
+  using namespace preview::literals;
+
+  const std::string s{"cosmos"};
+
+#if PREVIEW_CXX_VERSION >= 17
+  const ranges::take_view tv{s, 3};
+  const ranges::ref_view rv{tv};
+#else
+  const ranges::take_view<views::all_t<decltype(s)&>> tv{s, 3};
+  const ranges::ref_view<std::remove_reference_t<decltype(tv)>> rv{tv};
+#endif
+
+  EXPECT_FALSE(rv.empty());
+  EXPECT_EQ(rv.size(), 3);
+  EXPECT_EQ(*rv.begin(), 'c');
+  EXPECT_EQ(*(rv.end() - 1), 's');
+  EXPECT_EQ(std::strncmp(rv.data(), s.data(), 10), 0);
+  EXPECT_EQ(rv.base().size(), 3);
+  EXPECT_TRUE(ranges::equal(
+      rv,
+      "cos"_sv
+  ));
+}

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -120,6 +120,7 @@ TEST(VERSIONED(RangesViews), basic_istream_view) {
   }
 #endif
 
+#if !PREVIEW_ANDROID || (PREVIEW_CXX_VERSION < 17 || PREVIEW_NDK_VERSION_MAJOR >= 26)
   auto floats = std::istringstream{"1.1  2.2\t3.3\v4.4\f55\n66\r7.7  8.8"};
   std::ostringstream oss;
   ranges::copy(
@@ -128,6 +129,7 @@ TEST(VERSIONED(RangesViews), basic_istream_view) {
   );
 
   EXPECT_EQ(oss.str(), "1.1, 2.2, 3.3, 4.4, 55, 66, 7.7, 8.8, ");
+#endif
 }
 
 TEST(VERSIONED(RangesViews), repeat_view) {

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -289,3 +289,38 @@ TEST(VERSIONED(RangesViews), ref_view) {
       "cos"_sv
   ));
 }
+
+
+TEST(VERSIONED(RangesViews), owning_view) {
+  using namespace std::literals;
+  using namespace preview::literals;
+
+#if PREVIEW_CXX_VERSION > 17
+  ranges::owning_view ov{"cosmos"s}; // the deduced type of R is std::string;
+#else
+  ranges::owning_view<std::string> ov{"cosmos"s};
+#endif
+
+  EXPECT_FALSE(ov.empty());
+  EXPECT_EQ(ov.size(), 6);
+  EXPECT_EQ(ov.size(), ov.base().size());
+  EXPECT_EQ(ov.front(), 'c');
+  EXPECT_EQ(ov.front(), *ov.begin());
+  EXPECT_EQ(ov.back(), 's');
+  EXPECT_EQ(ov.back(), *(ov.end() - 1));
+  EXPECT_EQ(ov.data(), ov.base());
+
+  // typically equal to sizeof(R)
+  EXPECT_EQ(sizeof ov, sizeof(std::string));
+  for (const char ch : ov) { (void)ch; }
+
+  ranges::owning_view<std::string> ov2;
+  EXPECT_TRUE(ov2.empty());
+
+//  ov2 = ov; // compile-time error: copy assignment operator is deleted
+  EXPECT_FALSE_TYPE(std::is_copy_assignable<decltype(ov2)>);
+
+  ov2 = std::move(ov); // OK
+  EXPECT_EQ(ov2.size(), 6);
+  EXPECT_EQ(ov.size(), 0);
+}

--- a/test/ranges_views.cc
+++ b/test/ranges_views.cc
@@ -875,10 +875,11 @@ TEST(VERSIONED(RangesViews), split_view) {
     std::cout << '\n';
     EXPECT_TRUE(ranges::equal(
         letters,
-        "Keep..moving..forward.."_sv,
-        {},
-        [](auto subrange) { return preview::string_view{subrange}; },
-        [](char c) { return preview::string_view{&c, 1}; }
+        sentence,
+        [](preview::string_view sv, char c) {
+          return sv.size() == 1 && sv[0] == c;
+        },
+        [](auto subrange) { return preview::string_view{subrange}; }
     ));
   }
 


### PR DESCRIPTION
* Fix `derived_from_single_crtp` not detecting `range_adaptor_closure` in old MSVC
* Fix ranges-pipe-syntax not detecting non-template range adaptors 
* Fix bug in `ranges::cartesian_product_view`
* Fix `compressed_pair::swap` always participating in overload resolution
* Fix `is_equality_comparable` falls into infinite recursion in old GCC
* Fix `has_operator_string_view` detecting non-`operator string_view()` in MSVC
-----
* Update `std::apply` to C++23 standard
* Update readability of metaprogramming
-----
* Add tests for `<ranges>`
* Add constrained CTAD for `ranges::subrange`
* Add constrained CTAD for `ranges::iota_view`
* Add `tuple_integer_sequence`
* Add `swap(compressed_pair)`