### PR TITLE
Fix `compressed_pair` and its usage

### DIFF
--- a/include/preview/__functional/bind_partial.h
+++ b/include/preview/__functional/bind_partial.h
@@ -41,9 +41,7 @@ class bind_partial {
       std::is_constructible<BoundArgs, Args>...
   >::value, int> = 0>
   constexpr explicit bind_partial(F&& f, Args&&... args)
-      : pair_(compressed_pair_variadic_divider_t<1>{},
-              std::forward<F>(f),
-              std::forward<Args>(args)...) {}
+      : pair_(std::piecewise_construct, std::forward_as_tuple(std::forward<F>(f)), std::forward_as_tuple(std::forward<Args>(args))...) {}
 
   template<typename... CallArgs, std::enable_if_t<bind_invocable<Derived&, CallArgs&&...>::value, int> = 0>
   constexpr decltype(auto) operator()(CallArgs&&... call_args) &

--- a/include/preview/__functional/bind_partial.h
+++ b/include/preview/__functional/bind_partial.h
@@ -34,9 +34,14 @@ class bind_partial {
       : Derived::template bind_nothrow_invocable<DerivedSelf, CallArgs...> {};
 
  public:
-  template<typename F, typename... Args, std::enable_if_t<different_from<F, bind_partial>::value, int> = 0>
+  template<typename F, typename... Args, std::enable_if_t<conjunction<
+      different_from<F, bind_partial>,
+      std::is_constructible<FD, F>,
+      bool_constant<sizeof...(BoundArgs) == sizeof...(Args)>,
+      std::is_constructible<BoundArgs, Args>...
+  >::value, int> = 0>
   constexpr explicit bind_partial(F&& f, Args&&... args)
-      : pair_(compressed_pair_variadic_construct_divider<1>{},
+      : pair_(compressed_pair_variadic_divider_t<1>{},
               std::forward<F>(f),
               std::forward<Args>(args)...) {}
 

--- a/include/preview/__functional/not_fn.h
+++ b/include/preview/__functional/not_fn.h
@@ -20,8 +20,8 @@ namespace detail {
 struct not_fn_object_tag {};
 
 template<typename FD>
-class not_fn_object : private compressed_slot<FD, 0> {
-  using slot_base = compressed_slot<FD, 0>;
+class not_fn_object : private basic_compressed_slot<FD> {
+  using slot_base = basic_compressed_slot<FD>;
 
  public:
   template<typename F>
@@ -34,27 +34,27 @@ class not_fn_object : private compressed_slot<FD, 0> {
 
   template<typename... Args>
   constexpr auto operator()(Args&&... args) & noexcept(
-         noexcept(!preview::invoke(std::declval<FD&>()         , std::forward<Args>(args)...)))
-      -> decltype(!preview::invoke(std::declval<FD&>()         , std::forward<Args>(args)...))
-         { return !preview::invoke(slot_base::template get<0>(), std::forward<Args>(args)...); }
+         noexcept(!preview::invoke(std::declval<FD&>(), std::forward<Args>(args)...)))
+      -> decltype(!preview::invoke(std::declval<FD&>(), std::forward<Args>(args)...))
+         { return !preview::invoke(slot_base::value() , std::forward<Args>(args)...); }
 
   template<typename... Args>
   constexpr auto operator()(Args&&... args) const & noexcept(
-         noexcept(!preview::invoke(std::declval<const FD&>()   , std::forward<Args>(args)...)))
-      -> decltype(!preview::invoke(std::declval<const FD&>()   , std::forward<Args>(args)...))
-         { return !preview::invoke(slot_base::template get<0>(), std::forward<Args>(args)...); }
+         noexcept(!preview::invoke(std::declval<const FD&>(), std::forward<Args>(args)...)))
+      -> decltype(!preview::invoke(std::declval<const FD&>(), std::forward<Args>(args)...))
+         { return !preview::invoke(slot_base::value()       , std::forward<Args>(args)...); }
 
   template<typename... Args>
   constexpr auto operator()(Args&&... args) && noexcept(
-         noexcept(!preview::invoke(std::declval<FD&&>()        , std::forward<Args>(args)...)))
-      -> decltype(!preview::invoke(std::declval<FD&&>()        , std::forward<Args>(args)...))
-         { return !preview::invoke(slot_base::template get<0>(), std::forward<Args>(args)...); }
+         noexcept(!preview::invoke(std::declval<FD&&>()         , std::forward<Args>(args)...)))
+      -> decltype(!preview::invoke(std::declval<FD&&>()         , std::forward<Args>(args)...))
+         { return !preview::invoke(std::move(slot_base::value()), std::forward<Args>(args)...); }
 
   template<typename... Args>
   constexpr auto operator()(Args&&... args) const && noexcept(
-         noexcept(!preview::invoke(std::declval<const FD&&>()  , std::forward<Args>(args)...)))
-      -> decltype(!preview::invoke(std::declval<const FD&&>()  , std::forward<Args>(args)...))
-         { return !preview::invoke(slot_base::template get<0>(), std::forward<Args>(args)...); }
+         noexcept(!preview::invoke(std::declval<const FD&&>()   , std::forward<Args>(args)...)))
+      -> decltype(!preview::invoke(std::declval<const FD&&>()   , std::forward<Args>(args)...))
+         { return !preview::invoke(std::move(slot_base::value()), std::forward<Args>(args)...); }
 };
 
 template<typename F, F ConstFn>

--- a/include/preview/__tuple/make_from_tuple.h
+++ b/include/preview/__tuple/make_from_tuple.h
@@ -9,6 +9,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "preview/__tuple/tuple_integer_sequence.h"
 #include "preview/__tuple/tuple_like.h"
 #include "preview/__type_traits/conjunction.h"
 
@@ -20,7 +21,7 @@ constexpr T make_from_tuple_impl(Tuple&& t, std::index_sequence<I...>) {
   return T(std::get<I>(std::forward<Tuple>(t))...);
 }
 
-template<typename T, typename Tuple, typename I>
+template<typename T, typename Tuple, typename IndexSequence>
 struct is_constructible_from_tuple_impl;
 
 template<typename T, typename Tuple, std::size_t... I>
@@ -29,10 +30,7 @@ struct is_constructible_from_tuple_impl<T, Tuple, std::index_sequence<I...>>
 
 template<typename T, typename Tuple>
 struct is_constructible_from_tuple
-    : is_constructible_from_tuple_impl<T,
-                                       Tuple,
-                                       std::make_index_sequence<
-                                           std::tuple_size<std::remove_reference_t<Tuple>>::value>> {};
+    : is_constructible_from_tuple_impl<T, Tuple, tuple_index_sequence<Tuple>> {};
 
 } // namespace detail
 
@@ -41,9 +39,10 @@ template<typename T, typename Tuple, std::enable_if_t<conjunction<
     detail::is_constructible_from_tuple<T, Tuple>
 >::value, int> = 0>
 constexpr T make_from_tuple(Tuple&& t) {
-  return detail::make_from_tuple_impl<T>(
+  return preview::detail::make_from_tuple_impl<T>(
       std::forward<Tuple>(t),
-      std::make_index_sequence<std::tuple_size<std::remove_reference_t<Tuple>>::value>{});
+      tuple_index_sequence<Tuple>{}
+  );
 }
 
 } // namespace preview

--- a/include/preview/__utility/compressed_pair.h
+++ b/include/preview/__utility/compressed_pair.h
@@ -12,12 +12,11 @@
 #
 # include "preview/__core/inline_variable.h"
 # include "preview/__concepts/different_from.h"
+# include "preview/__tuple/make_from_tuple.h"
 # include "preview/__tuple/specialize_tuple.h"
-# include "preview/__type_traits/common_type.h"
+# include "preview/__tuple/tuple_like.h"
 # include "preview/__type_traits/conjunction.h"
 # include "preview/__type_traits/is_swappable.h"
-# include "preview/__utility/integer_sequence.h"
-# include "preview/__utility/in_place.h"
 
 namespace preview {
 namespace detail {
@@ -42,14 +41,12 @@ struct basic_compressed_slot {
 
 template<typename T>
 struct basic_compressed_slot<T, true> : public T {
-  constexpr basic_compressed_slot() = default;
-
-  template<typename Arg, typename... Args, std::enable_if_t<conjunction<
-    different_from<basic_compressed_slot, Arg>,
-    std::is_constructible<T, Arg, Args...>
+  template<typename... Args, std::enable_if_t<conjunction<
+    different_from_variadic<basic_compressed_slot, Args...>,
+    std::is_constructible<T, Args...>
   >::value, int> = 0>
-  constexpr basic_compressed_slot(Arg&& arg, Args&&... args)
-    : T(std::forward<Arg>(arg), std::forward<Args>(args)...) {}
+  constexpr basic_compressed_slot(Args&&... args)
+    : T(std::forward<Args>(args)...) {}
 
   constexpr       T&  value()       &  noexcept { return static_cast<      T& >(*this); }
   constexpr const T&  value() const &  noexcept { return static_cast<const T& >(*this); }
@@ -57,23 +54,13 @@ struct basic_compressed_slot<T, true> : public T {
   constexpr const T&& value() const && noexcept { return static_cast<const T&&>(*this); }
 };
 
-template<typename T, typename IndexSequence, typename Tuple>
-struct tuple_index_constructible_from;
-template<typename T, std::size_t... I, typename Tuple>
-struct tuple_index_constructible_from<T, std::index_sequence<I...>, Tuple>
-  : std::is_constructible<T, std::tuple_element_t<I, Tuple>...> {};
-
 template<typename T, std::size_t index>
 class compressed_slot : basic_compressed_slot<T> {
   using slot_base = basic_compressed_slot<T>;
-  using slot_base::value;
 
  public:
   using slot_base::slot_base;
-
-  template<typename U, std::size_t... I>
-  constexpr explicit compressed_slot(std::piecewise_construct_t, std::index_sequence<I...>, U&& ArgTuple)
-      : slot_base(std::get<I>(std::forward<U>(ArgTuple))...) {}
+  using slot_base::value;
 
   template<std::size_t I> constexpr std::enable_if_t<(I == index),       T&>  get()       &  noexcept { return value(); }
   template<std::size_t I> constexpr std::enable_if_t<(I == index), const T&>  get() const &  noexcept { return value(); }
@@ -86,15 +73,17 @@ class compressed_slot : basic_compressed_slot<T> {
 struct compressed_pair_empty_t {};
 PREVIEW_INLINE_VARIABLE constexpr compressed_pair_empty_t compressed_pair_empty;
 
-template<std::size_t I>
-struct compressed_pair_variadic_divider_t {};
-
 // A size-optimized pair using empty base optimization
 template<typename T, typename U>
 class compressed_pair : public detail::compressed_slot<T, 0>, public detail::compressed_slot<U, 1> {
  private:
   using first_base = detail::compressed_slot<T, 0>;
   using second_base = detail::compressed_slot<U, 1>;
+
+  template<typename Tuple1, typename Tuple2, std::size_t... I1, std::size_t... I2>
+  constexpr explicit compressed_pair(std::piecewise_construct_t, Tuple1&& t1, Tuple2&& t2, std::index_sequence<I1...>, std::index_sequence<I2...>)
+      : first_base (std::get<I1>(std::forward<Tuple1>(t1))...)
+      , second_base(std::get<I2>(std::forward<Tuple2>(t2))...) {}
 
  public:
   using first_type = T;
@@ -114,25 +103,30 @@ class compressed_pair : public detail::compressed_slot<T, 0>, public detail::com
       std::is_constructible<T, T2>,
       std::is_constructible<U, U2>
   >::value, int> = 0>
-  constexpr compressed_pair(T2&& t, U2&& u) : first_base(std::forward<T2>(t)), second_base(std::forward<U2>(u)) {}
+  constexpr compressed_pair(T2&& t, U2&& u)
+      : first_base(std::forward<T2>(t))
+      , second_base(std::forward<U2>(u)) {}
 
-  template<std::size_t N, typename... Args, std::enable_if_t<conjunction<
-      detail::tuple_index_constructible_from<T, make_index_sequence<0, N              >, std::tuple<Args&&...>>,
-      detail::tuple_index_constructible_from<U, make_index_sequence<N, sizeof...(Args)>, std::tuple<Args&&...>>
+  template<typename Tuple1, typename Tuple2, std::enable_if_t<conjunction<
+      tuple_like<Tuple1>,
+      tuple_like<Tuple2>,
+      detail::is_constructible_from_tuple<T, Tuple1>,
+      detail::is_constructible_from_tuple<U, Tuple2>
   >::value, int> = 0>
-  constexpr explicit compressed_pair(compressed_pair_variadic_divider_t<N>, Args&&... args)
-      : first_base (std::piecewise_construct, make_index_sequence<0, N              >{}, std::forward_as_tuple(args...))
-      , second_base(std::piecewise_construct, make_index_sequence<N, sizeof...(Args)>{}, std::forward_as_tuple(args...)) {}
+  constexpr explicit compressed_pair(std::piecewise_construct_t, Tuple1&& first_args, Tuple2&& second_args)
+      : compressed_pair(std::piecewise_construct,
+                        std::forward<Tuple1>(first_args), std::forward<Tuple2>(second_args),
+                        tuple_index_sequence<Tuple1>{}, tuple_index_sequence<Tuple2>{}) {}
 
-  constexpr T& first() & noexcept { return first_base::template get<0>(); }
-  constexpr T&& first() && noexcept { return std::move(first_base::template get<0>()); }
-  constexpr const T& first() const & noexcept { return first_base::template get<0>(); }
-  constexpr const T&& first() const && noexcept { return std::move(first_base::template get<0>()); }
+  constexpr       T&  first()       &  noexcept { return first_base::value(); }
+  constexpr const T&  first() const &  noexcept { return first_base::value(); }
+  constexpr       T&& first()       && noexcept { return std::move(first_base::value()); }
+  constexpr const T&& first() const && noexcept { return std::move(first_base::value()); }
 
-  constexpr U& second() & noexcept { return second_base::template get<1>(); }
-  constexpr U&& second() && noexcept { return std::move(second_base::template get<1>()); }
-  constexpr const U& second() const & noexcept { return second_base::template get<1>(); }
-  constexpr const U&& second() const && noexcept { return std::move(second_base::template get<1>()); }
+  constexpr       U&  second()       &  noexcept { return second_base::value(); }
+  constexpr const U&  second() const &  noexcept { return second_base::value(); }
+  constexpr       U&& second()       && noexcept { return std::move(second_base::value()); }
+  constexpr const U&& second() const && noexcept { return std::move(second_base::value()); }
 
   template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
       is_swappable<T>,
@@ -204,7 +198,6 @@ struct compressed_pair_getter<1> {
 };
 
 } // namespace detail
-
 } // namespace preview
 
 template<typename T, typename U> PREVIEW_SPECIALIZE_STD_TUPLE_SIZE(preview::compressed_pair<T, U>)


### PR DESCRIPTION
* Fix `compressed_pair::compressed_pair(compressed_pair_variadic_divider_t, ...)` participating in overload resolution in MSVC 2019