### PR TITLE
Add missing include in optional_test.cc

### DIFF
--- a/test/optional/optional_test.cc
+++ b/test/optional/optional_test.cc
@@ -9,6 +9,7 @@
 #include <charconv>
 #endif
 #include <cstring>
+#include <iomanip>
 #include <string>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
Platform: Arch Linux (x64), GCC 14.2.1 20240910

When building tests, I got this error in test/optional_test.cc :
```
[ 46%] Building CXX object test/CMakeFiles/optional_test_14.dir/optional/optional_test.cc.o
stl-preview/test/optional/optional_test.cc: In member function ‘virtual void optional_CXXSTD_14_OperatorArrowAndIndirect_Test::TestBody()’:
stl-preview/test/optional/optional_test.cc:105:34: error: ‘quoted’ is not a member of ‘std’
  105 |   std::cout << "taken: " << std::quoted(taken) << "\n"
      |                                  ^~~~~~
stl-preview/test/optional/optional_test.cc:20:1: note: ‘std::quoted’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
   19 | #include "preview/__ranges/views/transform.h"
  +++ |+#include <iomanip>
   20 | 
/home/Chi_Iroh/stl-preview/test/optional/optional_test.cc:106:68: error: ‘quoted’ is not a member of ‘std’
  106 |                                                   "opt2: " << std::quoted(*opt2) << ", size: " << opt2->size()  << '\n';
      |                                                                    ^~~~~~
stl-preview/test/optional/optional_test.cc:106:68: note: ‘std::quoted’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
make[2]: *** [test/CMakeFiles/optional_test_14.dir/build.make:76: test/CMakeFiles/optional_test_14.dir/optional/optional_test.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:3896: test/CMakeFiles/optional_test_14.dir/all] Error 2
make: *** [Makefile:101: all] Error 2
```

Adding `#include <iomanip>` fixed this error for me.