### PR TITLE
Added byteswap (from C++23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Implementation available in C++14 ~ :
 |                                     |                                                         |   |                                                        |                                                         |                                                        |                                                        |
 | [algorithm](#algorithm)             | ![](https://img.shields.io/badge/53/115-grey)![][p046]  |   | ![](https://img.shields.io/badge/2/4-grey)![][p050]    | ![](https://img.shields.io/badge/45/96-grey)![][p047]   | ![](https://img.shields.io/badge/8/18-grey)![][p044]   | ![](https://img.shields.io/badge/7/23-grey)![][p030]   |
 | [array](#array)                     | ![](https://img.shields.io/badge/1/1-grey)![][p100]     |   |                                                        | ![](https://img.shields.io/badge/1/1-grey)![][p100]     |                                                        |                                                        |
-| [bit](#bit)                         | ![](https://img.shields.io/badge/1/14-grey)![][p007]    |   |                                                        | ![](https://img.shields.io/badge/1/13-grey)![][p008]    | ![](https://img.shields.io/badge/0/1-grey)![][p000]    |                                                        |
+| [bit](#bit)                         | ![](https://img.shields.io/badge/2/14-grey)![][p014]    |   |                                                        | ![](https://img.shields.io/badge/1/13-grey)![][p008]    | ![](https://img.shields.io/badge/1/1-grey)![][p100]    |                                                        |
 | [concepts](#concepts)               | ![](https://img.shields.io/badge/30/30-grey)![][p100]   |   |                                                        | ![](https://img.shields.io/badge/30/30-grey)![][p100]   | ![](https://img.shields.io/badge/1/1-grey)![][p100]    |                                                        |
 | [cstddef](#cstddef)                 | ![](https://img.shields.io/badge/2/2-grey)![][p100]     |   | ![](https://img.shields.io/badge/2/2-grey)![][p100]    |                                                         |                                                        |                                                        |
 | [expected](#expected)               | ![](https://img.shields.io/badge/4/4-grey)![][p100]     |   |                                                        |                                                         | ![](https://img.shields.io/badge/4/4-grey)![][p100]    |                                                        |
@@ -359,7 +359,7 @@ Description
   |------------------|------------|----------|
   | `endian`         | ![][c20no] |          |
   | `bit_cast`       | ![][c20ok] |          |
-  | `byteswap`       | ![][c23no] |          |
+  | `byteswap`       | ![][c23ok] |          |
   | `has_single_bit` | ![][c20no] |          |
   | `bit_ceil`       | ![][c20no] |          |
   | `bit_floor`      | ![][c20no] |          |

--- a/include/preview/__bit/byteswap.h
+++ b/include/preview/__bit/byteswap.h
@@ -34,8 +34,8 @@ constexpr T byteswap_impl(T n, std::true_type /* is unsigned */) noexcept {
 }
 
 template<typename T, typename UnsignedT = typename std::make_unsigned<T>::type>
-constexpr UnsignedT byteswap_impl(T n, std::false_type /* is signed */) {
-  return preview::bit_cast<UnsignedT>(preview::detail::byteswap_impl<UnsignedT>(preview::bit_cast<UnsignedT>(n), std::true_type{}));
+constexpr T byteswap_impl(T n, std::false_type /* is signed */) {
+  return preview::bit_cast<T>(preview::detail::byteswap_impl<UnsignedT>(preview::bit_cast<UnsignedT>(n), std::true_type{}));
 }
 
 } // namespace detail

--- a/include/preview/__bit/byteswap.h
+++ b/include/preview/__bit/byteswap.h
@@ -11,7 +11,6 @@
 
 #include "preview/config.h"
 #include "preview/__bit/bit_cast.h"
-#include "preview/__type_traits/negation.h"
 
 #if PREVIEW_CXX_VERSION >= 23
   #include <bit>

--- a/include/preview/__bit/byteswap.h
+++ b/include/preview/__bit/byteswap.h
@@ -1,0 +1,56 @@
+//
+// Created by Chi-Iroh on 03/10/2024.
+//
+
+#ifndef PREVIEW_BIT_BYTESWAP_H_
+#define PREVIEW_BIT_BYTESWAP_H_
+
+#include <climits>
+#include <cstdint>
+#include <type_traits>
+
+#include "preview/config.h"
+#include "preview/__bit/bit_cast.h"
+#include "preview/__type_traits/negation.h"
+
+#if PREVIEW_CXX_VERSION >= 23
+    #include <bit>
+#endif
+
+namespace preview {
+    namespace detail {
+        template<typename T, std::enable_if_t<std::is_unsigned<T>::value, int> = 0>
+        constexpr T byteswap_impl(T n) noexcept {
+            constexpr T byte_mask{ (1 << CHAR_BIT) - 1 };
+
+            T result{ 0 };
+            for (unsigned i{ 0 }; i < sizeof(T); i++) {
+                const std::size_t nth_byte{ CHAR_BIT * (sizeof(T) - i - 1) };
+                const T byte{ static_cast<T>((n & (byte_mask << nth_byte)) >> nth_byte) };
+                result |= byte << (i * CHAR_BIT);
+            }
+            return result;
+        }
+
+        template<typename T, std::enable_if_t<std::is_signed<T>::value, int> = 0, typename UnsignedT = typename std::make_unsigned<T>::type>
+        constexpr UnsignedT byteswap_impl(T n) {
+            return byteswap_impl<UnsignedT>(preview::bit_cast<UnsignedT>(n));
+        }
+
+        template<typename T, std::enable_if_t<preview::negation_v<std::is_integral<T>>, int> = 0>
+        constexpr T byteswap_impl(T) {
+            static_assert(false, "byteswap needs integral type !");
+        }
+    }
+
+    template<typename T>
+    constexpr T byteswap(T n) noexcept {
+#if PREVIEW_CXX_VERSION >= 23
+    return std::byteswap<T>(n);
+#else
+    return preview::detail::byteswap_impl<T>(n);
+#endif
+    }
+}
+
+#endif

--- a/include/preview/__bit/byteswap.h
+++ b/include/preview/__bit/byteswap.h
@@ -14,43 +14,38 @@
 #include "preview/__type_traits/negation.h"
 
 #if PREVIEW_CXX_VERSION >= 23
-    #include <bit>
+  #include <bit>
 #endif
 
 namespace preview {
 namespace detail {
 
-template<typename T, std::enable_if_t<std::is_unsigned<T>::value, int> = 0>
-constexpr T byteswap_impl(T n) noexcept {
-    constexpr T byte_mask{ (1 << CHAR_BIT) - 1 };
+template<typename T>
+constexpr T byteswap_impl(T n, std::true_type /* is unsigned */) noexcept {
+  constexpr T byte_mask{ (1 << CHAR_BIT) - 1 };
+  T result{ 0 };
 
-    T result{ 0 };
-    for (unsigned i{ 0 }; i < sizeof(T); i++) {
-        const std::size_t nth_byte{ CHAR_BIT * (sizeof(T) - i - 1) };
-        const T byte{ static_cast<T>((n & (byte_mask << nth_byte)) >> nth_byte) };
-        result |= byte << (i * CHAR_BIT);
-    }
-    return result;
+  for (unsigned i{ 0 }; i < sizeof(T); i++) {
+    const std::size_t nth_byte{ CHAR_BIT * (sizeof(T) - i - 1) };
+    const T byte{ static_cast<T>((n & (byte_mask << nth_byte)) >> nth_byte) };
+    result |= byte << (i * CHAR_BIT);
+  }
+  return result;
 }
 
-template<typename T, std::enable_if_t<std::is_signed<T>::value, int> = 0, typename UnsignedT = typename std::make_unsigned<T>::type>
-constexpr UnsignedT byteswap_impl(T n) {
-    return byteswap_impl<UnsignedT>(preview::bit_cast<UnsignedT>(n));
-}
-
-template<typename T, std::enable_if_t<preview::negation_v<std::is_integral<T>>, int> = 0>
-constexpr T byteswap_impl(T) {
-    static_assert(false, "byteswap needs integral type !");
+template<typename T, typename UnsignedT = typename std::make_unsigned<T>::type>
+constexpr UnsignedT byteswap_impl(T n, std::false_type /* is signed */) {
+  return preview::bit_cast<UnsignedT>(preview::detail::byteswap_impl<UnsignedT>(preview::bit_cast<UnsignedT>(n), std::true_type{}));
 }
 
 } // namespace detail
 
-template<typename T>
-constexpr T byteswap(T n) noexcept {
+template<typename T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
+constexpr inline T byteswap(T n) noexcept {
 #if PREVIEW_CXX_VERSION >= 23
-    return std::byteswap<T>(n);
+  return std::byteswap<T>(n);
 #else
-    return preview::detail::byteswap_impl<T>(n);
+  return sizeof(T) == 1 ? n : preview::detail::byteswap_impl<T>(n, std::is_unsigned<T>{});
 #endif
 }
 

--- a/include/preview/__bit/byteswap.h
+++ b/include/preview/__bit/byteswap.h
@@ -36,8 +36,9 @@ constexpr T byteswap_impl(T n, std::true_type /* is unsigned */) noexcept {
   return result;
 }
 
-template<typename T, typename UnsignedT = typename std::make_unsigned<T>::type>
+template<typename T>
 constexpr T byteswap_impl(T n, std::false_type /* is signed */) {
+  using UnsignedT = typename std::make_unsigned<T>::type;
   return preview::bit_cast<T>(preview::detail::byteswap_impl<UnsignedT>(preview::bit_cast<UnsignedT>(n), std::true_type{}));
 }
 

--- a/include/preview/__bit/byteswap.h
+++ b/include/preview/__bit/byteswap.h
@@ -41,6 +41,16 @@ constexpr T byteswap_impl(T n, std::false_type /* is signed */) {
   return preview::bit_cast<T>(preview::detail::byteswap_impl<UnsignedT>(preview::bit_cast<UnsignedT>(n), std::true_type{}));
 }
 
+template<typename T, std::size_t Size>
+constexpr inline T byteswap_check_size(T n, std::integral_constant<std::size_t, Size>) {
+  return preview::detail::byteswap_impl<T>(n, std::is_unsigned<T>{});
+}
+
+template<typename T>
+constexpr inline T byteswap_check_size(T n, std::integral_constant<std::size_t, 1>) {
+  return n;
+}
+
 } // namespace detail
 
 template<typename T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
@@ -48,7 +58,7 @@ constexpr inline T byteswap(T n) noexcept {
 #if PREVIEW_CXX_VERSION >= 23
   return std::byteswap<T>(n);
 #else
-  return sizeof(T) == 1 ? n : preview::detail::byteswap_impl<T>(n, std::is_unsigned<T>{});
+  return preview::detail::byteswap_check_size<T>(n, std::integral_constant<std::size_t, sizeof(T)>{});
 #endif
 }
 

--- a/include/preview/__bit/byteswap.h
+++ b/include/preview/__bit/byteswap.h
@@ -24,11 +24,14 @@ template<typename T>
 constexpr T byteswap_impl(T n, std::true_type /* is unsigned */) noexcept {
   constexpr T byte_mask{ (1 << CHAR_BIT) - 1 };
   T result{ 0 };
+  unsigned upper_shift{ CHAR_BIT * (sizeof(T) - 1) };
+  unsigned lower_shift{ 0 };
 
   for (unsigned i{ 0 }; i < sizeof(T); i++) {
-    const std::size_t nth_byte{ CHAR_BIT * (sizeof(T) - i - 1) };
-    const T byte{ static_cast<T>((n & (byte_mask << nth_byte)) >> nth_byte) };
-    result |= byte << (i * CHAR_BIT);
+    const T byte{ static_cast<T>((n & (byte_mask << upper_shift)) >> upper_shift) };
+    result |= byte << lower_shift;
+    lower_shift += CHAR_BIT;
+    upper_shift -= CHAR_BIT;
   }
   return result;
 }

--- a/include/preview/bit.h
+++ b/include/preview/bit.h
@@ -6,5 +6,6 @@
 #define PREVIEW_BIT_H_
 
 #include "preview/__bit/bit_cast.h"
+#include "preview/__bit/byteswap.h"
 
 #endif // PREVIEW_BIT_H_

--- a/test/bit.cc
+++ b/test/bit.cc
@@ -20,3 +20,43 @@ TEST(VERSIONED(bit), bit_cast) {
   auto f64v2 = preview::bit_cast<double>(u64v2);
   EXPECT_EQ(preview::bit_cast<std::uint64_t>(f64v2), u64v2); // round-trip
 }
+
+TEST(VERSIONED(bit), byteswap_unsigned) {
+  constexpr std::uint8_t byte{ 0xCD };
+  EXPECT_EQ(preview::byteswap<std::uint8_t>(byte), byte);
+
+  constexpr std::uint16_t word{ 0xCA'FE };
+  EXPECT_EQ(preview::byteswap<std::uint16_t>(word), 0xFE'CA);
+  constexpr std::uint16_t word_same{ 0x44'44 };
+  EXPECT_EQ(preview::byteswap<std::uint16_t>(word_same), word_same);
+
+  constexpr std::uint32_t dword{ 0xDE'AD'BE'EF };
+  EXPECT_EQ(preview::byteswap<std::uint32_t>(dword), 0xEF'BE'AD'DE);
+  constexpr std::uint32_t dword_same{ 0x44'44'44'44 };
+  EXPECT_EQ(preview::byteswap<std::uint32_t>(dword_same), dword_same);
+
+  constexpr std::uint64_t qword{ 0x01'23'45'67'89'AB'CD'EF };
+  EXPECT_EQ(preview::byteswap<std::uint64_t>(qword), 0xEF'CD'AB'89'67'45'23'01);
+  constexpr std::uint64_t qword_same{ 0x44'44'44'44'44'44'44'44 };
+  EXPECT_EQ(preview::byteswap<std::uint64_t>(qword_same), qword_same);
+}
+
+TEST(VERSIONED(bit), byteswap_signed) {
+  constexpr std::int8_t byte{ 0x7D };
+  EXPECT_EQ(preview::byteswap<std::int8_t>(byte), byte);
+
+  constexpr std::int16_t word{ 0x7A'7E };
+  EXPECT_EQ(preview::byteswap<std::int16_t>(word), 0x7E'7A);
+  constexpr std::int16_t word_same{ 0x44'44 };
+  EXPECT_EQ(preview::byteswap<std::int16_t>(word_same), word_same);
+
+  constexpr std::int32_t dword{ 0x7E'AD'BE'7F };
+  EXPECT_EQ(preview::byteswap<std::int32_t>(dword), 0x7F'BE'AD'7E);
+  constexpr std::int32_t dword_same{ 0x44'44'44'44 };
+  EXPECT_EQ(preview::byteswap<std::int32_t>(dword_same), dword_same);
+
+  constexpr std::int64_t qword{ 0x01'23'45'67'89'AB'CD'44 };
+  EXPECT_EQ(preview::byteswap<std::int64_t>(qword), 0x44'CD'AB'89'67'45'23'01);
+  constexpr std::int64_t qword_same{ 0x44'44'44'44'44'44'44'44 };
+  EXPECT_EQ(preview::byteswap<std::int64_t>(qword_same), qword_same);
+}


### PR DESCRIPTION
Hello :wave: 

First of all, I really like the project, and I'd like to help a little when I have the time to.
I added byteswap function (from \<bit\> header since C++23), and I used __bit/bit_cast.h as a reference to be consistent.

I have no warning and all tests (bit_14, 17, 20 and 23) pass.
Please tell me if more tests are needed, I used values from cppreference (values were slightly modified for signed integers to avoid overflow).