### PR TITLE
Downgrade to ubuntu 22.04

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -97,10 +97,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         build_type: [Debug, Release]
         compiler: [clang]
         compiler_version: [11, 12, 13, 14, 15]
+        platform: [x64, x86]
         include:
           - cc_compiler: clang
           - cxx_compiler: clang++
@@ -112,6 +113,7 @@ jobs:
       uses: egor-tensin/setup-clang@v1
       with:
         version: ${{ matrix.compiler_version }}
+        platform: ${{ matrix.platform }}
 
     - name: Configure CMake
       env:


### PR DESCRIPTION
Downgrade Ubuntu runner to `ubuntu-22.04` since `ubuntu-latest` now uses `ubuntu-24.04`