### PR TITLE
Fix ranges::equal

### DIFF
--- a/include/preview/__algorithm/ranges/equal.h
+++ b/include/preview/__algorithm/ranges/equal.h
@@ -57,13 +57,22 @@ struct equal_niebloid {
     return true;
   }
 
-  template<typename I1, typename S1, typename I2, typename S2, typename Pred, typename Proj1, typename Proj2>
-  static constexpr bool compare_application(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred, Proj1 proj1, Proj2 proj2) {
+  template<typename I2, typename S2>
+  static constexpr bool check_eq(I2, S2, std::true_type /* size_checked */) {
+    return true;
+  }
+  template<typename I2, typename S2>
+  static constexpr bool check_eq(I2 first2, S2 last2, std::false_type /* size_checked */) {
+    return first2 == last2;
+  }
+
+  template<typename I1, typename S1, typename I2, typename S2, typename Pred, typename Proj1, typename Proj2, typename B>
+  static constexpr bool compare_application(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred, Proj1 proj1, Proj2 proj2, B size_checked) {
     for (; first1 != last1; ++first1, (void)++first2) {
       if (!preview::invoke(pred, preview::invoke(proj1, *first1), preview::invoke(proj2, *first2)))
         return false;
     }
-    return first2 == last2;
+    return check_eq(std::move(first2), std::move(last2), size_checked);
   }
 
  public:
@@ -80,13 +89,15 @@ struct equal_niebloid {
   >
   PREVIEW_NODISCARD constexpr bool
   operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const {
-    if (!try_compare_size(first1, last1, first2, last2, conjunction<sized_sentinel_for<S1, I1>, sized_sentinel_for<S2, I2>>{}))
+    using can_check_size = conjunction<sized_sentinel_for<S1, I1>, sized_sentinel_for<S2, I2>>;
+
+    if (!try_compare_size(first1, last1, first2, last2, can_check_size{}))
       return false;
 
     return compare_application(
         std::move(first1), std::move(last1),
         std::move(first2), std::move(last2),
-        preview::wrap_functor(pred), preview::wrap_functor(proj1), preview::wrap_functor(proj2));
+        preview::wrap_functor(pred), preview::wrap_functor(proj1), preview::wrap_functor(proj2), can_check_size{});
   }
 
   template<
@@ -98,13 +109,15 @@ struct equal_niebloid {
   >
   PREVIEW_NODISCARD constexpr bool
   operator()(R1&& r1, R2&& r2, Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}) const {
-    if (!try_compare_size(r1, r2, conjunction<sized_range<R1>, sized_range<R2>>{}))
+    using can_check_size = conjunction<sized_range<R1>, sized_range<R2>>;
+
+    if (!try_compare_size(r1, r2, can_check_size{}))
       return false;
 
     return compare_application(
         ranges::begin(r1), ranges::end(r1),
         ranges::begin(r2), ranges::end(r2),
-        preview::wrap_functor(pred), preview::wrap_functor(proj1), preview::wrap_functor(proj2));
+        preview::wrap_functor(pred), preview::wrap_functor(proj1), preview::wrap_functor(proj2), can_check_size{});
   }
 
   template<

--- a/test/algorithm.cc
+++ b/test/algorithm.cc
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "preview/algorithm.h"
+#include "preview/array.h"
 #include "preview/ranges.h"
 
 #include "test_utils.h"

--- a/test/algorithm_ranges.cc
+++ b/test/algorithm_ranges.cc
@@ -8,8 +8,9 @@
 #include <list>
 #include <map>
 #include <numeric>
-#include <string>
 #include <random>
+#include <set>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -18,6 +19,7 @@
 #include "preview/functional.h"
 #include "preview/ranges.h"
 #include "preview/span.h"
+#include "preview/string_view.h"
 #include "preview/utility.h"
 
 #include "test_utils.h"
@@ -665,4 +667,50 @@ TEST(VERSIONED(AlgorithmRanges), starts_with) {
   EXPECT_TRUE(ranges::starts_with(map, views::iota(1, 3), {}, preview::key));
 
   EXPECT_FALSE(ranges::starts_with(map, views::iota(1, 3), {}, preview::key, [](auto x) { return x * x; }));
+}
+
+TEST(VERSIONED(AlgorithmRanges), equal) {
+  {
+    std::vector<int> v1 = {1, 2, 3, 4, 5};
+    std::vector<int> v2 = {1, 2, 3, 4, 5};
+    EXPECT_TRUE(ranges::equal(v1, v2));
+    EXPECT_TRUE(ranges::equal(v2, v1));
+
+    v2[0] = 0;
+    EXPECT_FALSE(ranges::equal(v1, v2));
+    EXPECT_FALSE(ranges::equal(v2, v1));
+
+    std::set<int> s1 = {1, 2, 3, 4};
+    EXPECT_FALSE(ranges::equal(v1, s1));
+    EXPECT_FALSE(ranges::equal(s1, v1));
+
+    s1.emplace(5);
+    EXPECT_TRUE(ranges::equal(v1, s1));
+    EXPECT_TRUE(ranges::equal(s1, v1));
+
+    std::set<int> s2 = {1, 2, 3, 4};
+    EXPECT_FALSE(ranges::equal(s1, s2));
+    EXPECT_FALSE(ranges::equal(s2, s1));
+
+    s2.emplace(5);
+    EXPECT_TRUE(ranges::equal(s1, s2));
+    EXPECT_TRUE(ranges::equal(s2, s1));
+  }
+
+  {
+    std::set<preview::string_view> r1 = {"x"};
+    std::set<std::string> r2 = {"x", "y"};
+
+    EXPECT_FALSE(ranges::equal(r1, r2));
+    EXPECT_FALSE(ranges::equal(r2, r1));
+  }
+
+  { // test uncommon range
+    EXPECT_FALSE(ranges::equal(views::iota(0) | views::take(5), views::iota(0) | views::take(10)));
+    EXPECT_FALSE(ranges::equal(views::iota(0) | views::take(10), views::iota(0) | views::take(5)));
+
+    EXPECT_TRUE(ranges::equal(views::iota(0) | views::take(5), views::iota(0) | views::take(5)));
+    EXPECT_TRUE(ranges::equal(views::iota(0) | views::take(5), views::iota(0, 5)));
+    EXPECT_TRUE(ranges::equal(views::iota(0, 5), views::iota(0) | views::take(5)));
+  }
 }

--- a/test/ranges.cc
+++ b/test/ranges.cc
@@ -286,8 +286,8 @@ TEST(VERSIONED(Ranges), to) {
   std::cout << map[1] << std::endl;
   std::cout << map[2] << std::endl;
   EXPECT_EQ(map[0], 'A');
-  EXPECT_TRUE((ranges::equal(map | views::keys, {0, 1, 2, 3, 4})));
-  EXPECT_TRUE((ranges::equal(map | views::values, {'A', 'B', 'C', 'D', 'E'})));
+  EXPECT_TRUE((ranges::equal(map | views::keys, {0, 1, 2, 3})));
+  EXPECT_TRUE((ranges::equal(map | views::values, {'A', 'B', 'C', 'D'})));
 
   auto f1 = views::iota(1, 5) | views::transform([](auto const v){ return v * 2; });
 


### PR DESCRIPTION
* Add missing size check for `sized_range`
* Fix not checking if size is equal for non-`sized_sentinel_for` types.